### PR TITLE
Update langfuse.tf

### DIFF
--- a/langfuse.tf
+++ b/langfuse.tf
@@ -104,6 +104,8 @@ langfuse:
       paths:
       - path: /
         pathType: Prefix
+    securityContext:
+      allowPrivilegeEscalation: false
 EOT
   encryption_values = !var.use_encryption_key ? "" : <<EOT
 langfuse:


### PR DESCRIPTION
Deny priviledge escalation explicitly to resolve insecure alert in Google SCC

**Description**
A container has been explicitly configured to allow privilege escalation on execution. This permits a process created within the container to execute a set-user-id, set-group-id or file capability executable to gain the privileges specified by the executable. The lack of preventive security control increases the risk of container escape.

**Recommended action**
Apply the following steps to: affected resources.
Open the YAML for an affected workload.
Set the following restricted fields to one of the allowed values:

**Restricted fields**

- spec.containers[*].securityContext.allowPrivilegeEscalation
- spec.initContainers[*].securityContext.allowPrivilegeEscalation
- spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation

**Allowed values**
- false

reference: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted