### PR TITLE
fix: grant the Service Account Token Creator role to the service account to enable media upload and batch export #14 #16

### DIFF
--- a/langfuse.tf
+++ b/langfuse.tf
@@ -122,6 +122,12 @@ resource "google_service_account_iam_binding" "workload_identity_binding" {
   ]
 }
 
+resource "google_service_account_iam_member" "langfuse_token_creator" {
+  service_account_id = google_service_account.langfuse.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.langfuse.email}"
+}
+
 resource "kubernetes_namespace" "langfuse" {
   metadata {
     name = var.kubernetes_namespace


### PR DESCRIPTION
### Overview
Grant `roles/iam.serviceAccountTokenCreator` role to the Langfuse service account to fix media upload and batch export functionality.

### Problem
- Media upload fails with `Permission 'iam.serviceAccounts.signBlob' denied` error ([#14](https://github.com/langfuse/langfuse-terraform-gcp/issues/14))
- Batch export fails with similar permission error ([#16](https://github.com/langfuse/langfuse-terraform-gcp/issues/16))

### Solution
Grant required `signBlob` permission for signed URL generation in Google Cloud Storage when using Workload Identity:

```hcl
resource "google_service_account_iam_member" "langfuse_token_creator" {
  service_account_id = google_service_account.langfuse.name
  role               = "roles/iam.serviceAccountTokenCreator"
  member             = "serviceAccount:${google_service_account.langfuse.email}"
}
```

### Benefits
- No service account key management required
- Follows GCP best practices
- Works out of the box after deployment

**Fixes #14 #16**