### PR TITLE
feat: add additional_helm_values variable for custom Helm configuration

### DIFF
--- a/langfuse.tf
+++ b/langfuse.tf
@@ -174,11 +174,12 @@ resource "helm_release" "langfuse" {
   chart      = "langfuse"
   namespace  = kubernetes_namespace.langfuse.metadata[0].name
 
-  values = [
+  values = compact([
     local.langfuse_values,
     local.ingress_values,
     local.encryption_values,
-  ]
+    var.additional_helm_values,
+  ])
 
   depends_on = [
     kubernetes_secret.langfuse,

--- a/variables.tf
+++ b/variables.tf
@@ -99,3 +99,9 @@ variable "additional_env" {
     error_message = "Each environment variable must have either 'value' or 'valueFrom' specified, but not both."
   }
 }
+
+variable "additional_helm_values" {
+  description = "Additional Helm values to merge into the Langfuse chart. Useful for configuring nodeSelector, tolerations, resources, etc."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Add `additional_helm_values` variable to allow users to pass custom Helm values to the Langfuse chart.

## Use Case

This enables configuring:
- Node selectors (e.g., GKE Spot VMs for cost optimization)
- Tolerations
- Resource limits/requests
- Any other Helm chart values not exposed as module variables

## Example

```hcl
module "langfuse" {
  source = "github.com/langfuse/langfuse-terraform-gcp"
  
  domain = "langfuse.example.com"
  
  additional_helm_values = <<-EOT
    langfuse:
      web:
        nodeSelector:
          cloud.google.com/gke-spot: "true"
        tolerations:
          - key: cloud.google.com/gke-spot
            operator: Equal
            value: "true"
            effect: NoSchedule
  EOT
}
```

## Changes

- Add `additional_helm_values` variable (string, default "")
- Update `helm_release.langfuse` to include additional values using `compact()` to filter empty strings