### PR TITLE
Add clickhouse_storage_size variable for PVC sizing

### DIFF
--- a/langfuse.tf
+++ b/langfuse.tf
@@ -60,6 +60,8 @@ clickhouse:
   auth:
     existingSecret: ${kubernetes_secret.langfuse.metadata[0].name}
     existingSecretKey: clickhouse-password
+  persistence:
+    size: ${var.clickhouse_storage_size}
 redis:
   deploy: false
   host: ${google_redis_instance.this.host}

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,12 @@ variable "langfuse_chart_version" {
   default     = "1.5.14"
 }
 
+variable "clickhouse_storage_size" {
+  description = "PVC size for each ClickHouse replica"
+  type        = string
+  default     = "100Gi"
+}
+
 variable "additional_env" {
   description = "Additional environment variables to add to the Langfuse container. Supports both direct values and Kubernetes valueFrom references (secrets, configMaps)."
   type = list(object({


### PR DESCRIPTION
The Bitnami ClickHouse subchart defaults to 8Gi PVCs which is insufficient for production workloads. This adds a configurable variable (defaulting to 100Gi) that passes through to the clickhouse.persistence.size Helm value.