### PR TITLE
feat: make DNS zone creation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ module "langfuse" {
 | deletion_protection                 | Whether or not to enable deletion_protection on data sensitive resources                                                                                                                                  | bool         | true                    |    no    |
 | langfuse_chart_version              | Version of the Langfuse Helm chart to deploy                                                                                                                                                              | string       | "1.5.14"                |    no    |
 | additional_env                      | Additional environment variables to add to the Langfuse container. Supports both direct values and Kubernetes valueFrom references (secrets, configMaps). See examples/additional-env for usage examples. | list(object) | []                      |    no    |
+| create_dns_zone                     | Whether to create a Google Cloud DNS managed zone. Set to `false` if you manage DNS externally.                                                                                                           | bool         | true                    |    no    |
 
 ## Outputs
 

--- a/dns.tf
+++ b/dns.tf
@@ -1,5 +1,6 @@
 # Create Cloud DNS zone
 resource "google_dns_managed_zone" "this" {
+  count       = var.create_dns_zone ? 1 : 0
   name        = replace(var.domain, ".", "-")
   dns_name    = "${var.domain}."
   description = "DNS zone for Langfuse domain"
@@ -19,8 +20,9 @@ data "kubernetes_ingress_v1" "langfuse" {
 
 # Create DNS A record for the load balancer
 resource "google_dns_record_set" "this" {
-  name         = google_dns_managed_zone.this.dns_name
-  managed_zone = google_dns_managed_zone.this.name
+  count        = var.create_dns_zone ? 1 : 0
+  name         = google_dns_managed_zone.this[0].dns_name
+  managed_zone = google_dns_managed_zone.this[0].name
   type         = "A"
   ttl          = 300
 

--- a/variables.tf
+++ b/variables.tf
@@ -117,3 +117,9 @@ variable "additional_env" {
     error_message = "Each environment variable must have either 'value' or 'valueFrom' specified, but not both."
   }
 }
+
+variable "create_dns_zone" {
+  description = "Whether to create a Google Cloud DNS managed zone. Set to `false` if you manage DNS externally."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
# Make DNS zone creation optional

## Motivation and Context
This PR introduces the ability to optionally skip the creation of a Google Cloud DNS managed zone. This is particularly useful for users who manage their DNS externally or through a centralize infrastructure team and do not wish to delegate a zone to Google Cloud.

## Changes
- Introduced a new variable `create_dns_zone` (defaulting to `true` for backward compatibility).
- Added `count` to the `google_dns_managed_zone.this` resource.
- Added `count` to the `google_dns_record_set.this` resource.

## How to test
Set `create_dns_zone = false` in your module configuration and verify that Terraform does not attempt to create the `google_dns_managed_zone` or `google_dns_record_set` resources.

## Checklist
- [x] `terraform fmt` has been run.
- [x] `terraform validate` reveals no errors.
- [x] Changes are documented in variables.tf.