### PR TITLE
feat!: deploy ClickHouse via the ClickHouse operator, support external clickhouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,46 @@ This module creates a complete Langfuse stack with the following components:
 - Cloud SQL PostgreSQL instance
 - Cloud Memorystore Redis instance
 - Cloud Storage bucket for storage
+- ClickHouse cluster managed by the official [ClickHouse Kubernetes operator](https://github.com/ClickHouse/clickhouse-operator) (including ClickHouse Keeper and cert-manager), or optionally an external ClickHouse such as ClickHouse Cloud
 - TLS certificates and Cloud DNS configuration
 - Required IAM roles and firewall rules
 - GKE Ingress Controller for ingress
 - Filestore CSI Driver for persistent storage
+
+## ClickHouse
+
+By default the module deploys a ClickHouse cluster into the GKE cluster using the official [ClickHouse Kubernetes operator](https://github.com/ClickHouse/clickhouse-operator) instead of the Bitnami ClickHouse chart bundled with the Langfuse Helm chart. This avoids any dependency on the deprecated `bitnamilegacy` container images, which no longer receive updates or security patches. The module installs:
+
+- [cert-manager](https://cert-manager.io/) (required by the operator to issue its admission webhook certificates)
+- The ClickHouse operator (`oci://ghcr.io/clickhouse/clickhouse-operator-helm`)
+- A `ClickHouseCluster` (1 shard, `clickhouse_replicas` replicas) and a `KeeperCluster` via the official cluster chart (`oci://ghcr.io/clickhouse/clickhouse-cluster-helm`)
+
+The deployment can be sized with the `clickhouse_replicas`, `clickhouse_resources`, `clickhouse_storage_size`, `clickhouse_storage_class`, `clickhouse_keeper_replicas`, and `clickhouse_keeper_storage_size` variables.
+
+### External ClickHouse (bring your own)
+
+To use an existing ClickHouse instead — for example [ClickHouse Cloud](https://clickhouse.com/cloud) — set `external_clickhouse`. The module then skips cert-manager, the operator, and the in-cluster ClickHouse entirely. See [examples/external-clickhouse](examples/external-clickhouse/external-clickhouse.tf) for a full example.
+
+```hcl
+module "langfuse" {
+  source = "github.com/langfuse/langfuse-terraform-gcp"
+
+  domain = "langfuse.example.com"
+
+  external_clickhouse = {
+    host = "https://abc123.europe-west4.gcp.clickhouse.cloud"
+    # Defaults: http_port = 8443, native_port = 9440, username = "default",
+    # database = "default", cluster_enabled = true, migration_ssl = true
+  }
+  external_clickhouse_password = var.clickhouse_password
+}
+```
+
+Set `cluster_enabled = false` for ClickHouse Cloud on Azure or for single-node deployments. Make sure the GKE cluster can reach the external ClickHouse (for ClickHouse Cloud, check the IP allowlist or use Private Service Connect).
+
+### Migrating from module versions <= 0.3.x
+
+Earlier versions of this module deployed ClickHouse (and ZooKeeper) through the Bitnami subchart of the Langfuse Helm chart. **Upgrading is a breaking change: the operator-managed ClickHouse starts empty and there is no automated data migration.** Trace, observation, and score data lives in ClickHouse, so existing installations must copy it over (e.g. `BACKUP`/`RESTORE` through a GCS bucket, or `INSERT INTO ... SELECT ... FROM remote(...)` while the old StatefulSet's PVCs still exist). New installations are unaffected. If you need to stay on the Bitnami-based deployment for now, pin this module to `0.3.x`.
 
 ## Additional Environment Variables
 
@@ -164,7 +200,7 @@ module "langfuse" {
 | google      | >= 5.0  |
 | google-beta | >= 5.0  |
 | kubernetes  | >= 2.10 |
-| helm        | >= 2.5  |
+| helm        | >= 2.7  |
 
 ## Providers
 
@@ -173,7 +209,7 @@ module "langfuse" {
 | google      | >= 5.0  |
 | google-beta | >= 5.0  |
 | kubernetes  | >= 2.10 |
-| helm        | >= 2.5  |
+| helm        | >= 2.7  |
 | random      | >= 3.0  |
 | tls         | >= 3.0  |
 
@@ -204,6 +240,8 @@ module "langfuse" {
 | kubernetes_secret.langfuse                  | resource |
 | helm_release.ingress_nginx                  | resource |
 | helm_release.cert_manager                   | resource |
+| helm_release.clickhouse_operator            | resource |
+| helm_release.clickhouse                     | resource |
 | random_password.database                    | resource |
 | tls_private_key.langfuse                    | resource |
 
@@ -222,6 +260,16 @@ module "langfuse" {
 | cache_tier                          | The service tier of the instance                                                                                                                                                                          | string       | "STANDARD_HA"           |    no    |
 | cache_memory_size_gb                | Redis memory size in GB                                                                                                                                                                                   | number       | 1                       |    no    |
 | deletion_protection                 | Whether or not to enable deletion_protection on data sensitive resources                                                                                                                                  | bool         | true                    |    no    |
+| clickhouse_replicas                 | Number of ClickHouse replicas (single shard). The default of 3 provides a highly available setup. Only used when ClickHouse is deployed in-cluster.                                                       | number       | 3                       |    no    |
+| clickhouse_keeper_replicas          | Number of ClickHouse Keeper replicas. Must be 1, 3 or 5 to maintain quorum. Only used when ClickHouse is deployed in-cluster.                                                                             | number       | 3                       |    no    |
+| clickhouse_storage_size             | Size of the persistent volume of each ClickHouse replica                                                                                                                                                  | string       | "100Gi"                 |    no    |
+| clickhouse_keeper_storage_size      | Size of the persistent volume of each ClickHouse Keeper replica                                                                                                                                           | string       | "10Gi"                  |    no    |
+| clickhouse_storage_class            | StorageClass used for the ClickHouse and ClickHouse Keeper volumes                                                                                                                                        | string       | "premium-rwo"           |    no    |
+| clickhouse_resources                | Resource requests for each ClickHouse replica. On GKE Autopilot the limits default to the requests.                                                                                                       | object       | { cpu = "2", memory = "8Gi" } | no |
+| clickhouse_operator_chart_version   | Version of the ClickHouse operator and ClickHouse cluster Helm charts (kept in lockstep)                                                                                                                  | string       | "0.0.7"                 |    no    |
+| cert_manager_chart_version          | Version of the cert-manager Helm chart. cert-manager issues the certificates for the ClickHouse operator admission webhooks.                                                                              | string       | "v1.21.0"               |    no    |
+| external_clickhouse                 | Use an external ClickHouse deployment (e.g. ClickHouse Cloud) instead of deploying ClickHouse into the GKE cluster. See [External ClickHouse](#external-clickhouse-bring-your-own).                       | object       | null                    |    no    |
+| external_clickhouse_password        | Password for the external ClickHouse user. Required when external_clickhouse is set.                                                                                                                      | string       | ""                      |    no    |
 | langfuse_chart_version              | Version of the Langfuse Helm chart to deploy                                                                                                                                                              | string       | "1.5.14"                |    no    |
 | additional_env                      | Additional environment variables to add to the Langfuse container. Supports both direct values and Kubernetes valueFrom references (secrets, configMaps). See examples/additional-env for usage examples. | list(object) | []                      |    no    |
 | create_dns_zone                     | Whether to create a Google Cloud DNS managed zone. Set to `false` if you manage DNS externally.                                                                                                           | bool         | true                    |    no    |

--- a/clickhouse.tf
+++ b/clickhouse.tf
@@ -6,3 +6,138 @@ resource "random_password" "clickhouse_password" {
   min_upper   = 1
   min_numeric = 1
 }
+
+locals {
+  # Deploy ClickHouse into the GKE cluster unless an external one is configured
+  deploy_clickhouse = var.external_clickhouse == null
+
+  # Name of the ClickHouseCluster resource. The operator exposes the cluster
+  # through a headless service named <name>-clickhouse-headless.
+  clickhouse_cluster_name = "langfuse"
+
+  clickhouse_host            = local.deploy_clickhouse ? "${local.clickhouse_cluster_name}-clickhouse-headless" : var.external_clickhouse.host
+  clickhouse_http_port       = local.deploy_clickhouse ? 8123 : var.external_clickhouse.http_port
+  clickhouse_native_port     = local.deploy_clickhouse ? 9000 : var.external_clickhouse.native_port
+  clickhouse_username        = local.deploy_clickhouse ? "default" : var.external_clickhouse.username
+  clickhouse_database        = local.deploy_clickhouse ? "default" : var.external_clickhouse.database
+  clickhouse_cluster_enabled = local.deploy_clickhouse ? true : var.external_clickhouse.cluster_enabled
+  clickhouse_migration_ssl   = local.deploy_clickhouse ? false : var.external_clickhouse.migration_ssl
+}
+
+# cert-manager issues the TLS certificates for the ClickHouse operator's
+# admission webhooks
+resource "helm_release" "cert_manager" {
+  count = local.deploy_clickhouse ? 1 : 0
+
+  name             = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  version          = var.cert_manager_chart_version
+  namespace        = "cert-manager"
+  create_namespace = true
+
+  # Explicit resource requests to avoid the GKE Autopilot defaults of
+  # 500m CPU / 2Gi memory per container
+  values = [<<EOT
+crds:
+  enabled: true
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+webhook:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+cainjector:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+EOT
+  ]
+}
+
+# Official ClickHouse Kubernetes operator
+resource "helm_release" "clickhouse_operator" {
+  count = local.deploy_clickhouse ? 1 : 0
+
+  name             = "clickhouse-operator"
+  repository       = "oci://ghcr.io/clickhouse"
+  chart            = "clickhouse-operator-helm"
+  version          = var.clickhouse_operator_chart_version
+  namespace        = "clickhouse-operator-system"
+  create_namespace = true
+
+  depends_on = [helm_release.cert_manager]
+}
+
+# ClickHouse and ClickHouse Keeper, rendered as ClickHouseCluster and
+# KeeperCluster resources and reconciled by the operator. The cluster chart
+# version is kept in lockstep with the operator chart version. The operator
+# names the ClickHouse cluster "default" in remote_servers, which matches the
+# cluster name expected by the Langfuse migrations.
+resource "helm_release" "clickhouse" {
+  count = local.deploy_clickhouse ? 1 : 0
+
+  name       = "clickhouse"
+  repository = "oci://ghcr.io/clickhouse"
+  chart      = "clickhouse-cluster-helm"
+  version    = var.clickhouse_operator_chart_version
+  namespace  = kubernetes_namespace.langfuse.metadata[0].name
+
+  values = [<<EOT
+clickhouse:
+  meta:
+    name: ${local.clickhouse_cluster_name}
+  spec:
+    replicas: ${var.clickhouse_replicas}
+    dataVolumeClaimSpec:
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: ${var.clickhouse_storage_class}
+      resources:
+        requests:
+          storage: ${var.clickhouse_storage_size}
+    containerTemplate:
+      resources:
+        requests:
+          cpu: ${var.clickhouse_resources.cpu}
+          memory: ${var.clickhouse_resources.memory}
+    podTemplate:
+      topologyZoneKey: topology.kubernetes.io/zone
+      nodeHostnameKey: kubernetes.io/hostname
+    settings:
+      defaultUserPassword:
+        secret:
+          name: ${kubernetes_secret.langfuse.metadata[0].name}
+          key: clickhouse-password
+keeper:
+  meta:
+    name: ${local.clickhouse_cluster_name}
+  spec:
+    replicas: ${var.clickhouse_keeper_replicas}
+    dataVolumeClaimSpec:
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: ${var.clickhouse_storage_class}
+      resources:
+        requests:
+          storage: ${var.clickhouse_keeper_storage_size}
+    containerTemplate:
+      resources:
+        requests:
+          cpu: 250m
+          memory: 1Gi
+    podTemplate:
+      topologyZoneKey: topology.kubernetes.io/zone
+      nodeHostnameKey: kubernetes.io/hostname
+EOT
+  ]
+
+  depends_on = [
+    helm_release.clickhouse_operator,
+    kubernetes_secret.langfuse,
+  ]
+}

--- a/examples/external-clickhouse/external-clickhouse.tf
+++ b/examples/external-clickhouse/external-clickhouse.tf
@@ -1,0 +1,46 @@
+# Deploys Langfuse against an external ClickHouse (e.g. ClickHouse Cloud)
+# instead of running ClickHouse inside the GKE cluster. With an external
+# ClickHouse configured, the module does not install cert-manager, the
+# ClickHouse operator, or an in-cluster ClickHouse.
+
+variable "clickhouse_password" {
+  description = "Password of the external ClickHouse user"
+  type        = string
+  sensitive   = true
+}
+
+module "langfuse" {
+  source = "../.."
+
+  domain = "langfuse.example.com"
+
+  # ClickHouse Cloud connection. The defaults match ClickHouse Cloud:
+  # HTTPS on port 8443 and the TLS native protocol on port 9440.
+  external_clickhouse = {
+    host = "https://abc123.europe-west4.gcp.clickhouse.cloud"
+
+    # Uncomment for ClickHouse Cloud on Azure or single-node deployments:
+    # cluster_enabled = false
+
+    # For a self-managed ClickHouse without TLS instead:
+    # host          = "clickhouse.internal.example.com"
+    # http_port     = 8123
+    # native_port   = 9000
+    # migration_ssl = false
+  }
+  external_clickhouse_password = var.clickhouse_password
+}
+
+provider "kubernetes" {
+  host                   = module.langfuse.cluster_host
+  cluster_ca_certificate = module.langfuse.cluster_ca_certificate
+  token                  = module.langfuse.cluster_token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.langfuse.cluster_host
+    cluster_ca_certificate = module.langfuse.cluster_ca_certificate
+    token                  = module.langfuse.cluster_token
+  }
+}

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -57,9 +57,18 @@ postgresql:
     secretKeys:
       userPasswordKey: postgres-password
 clickhouse:
+  deploy: false
+  host: ${jsonencode(local.clickhouse_host)}
+  httpPort: ${local.clickhouse_http_port}
+  nativePort: ${local.clickhouse_native_port}
+  database: ${jsonencode(local.clickhouse_database)}
+  clusterEnabled: ${local.clickhouse_cluster_enabled}
   auth:
+    username: ${jsonencode(local.clickhouse_username)}
     existingSecret: ${kubernetes_secret.langfuse.metadata[0].name}
     existingSecretKey: clickhouse-password
+  migration:
+    ssl: ${local.clickhouse_migration_ssl}
 redis:
   deploy: false
   host: ${google_redis_instance.this.host}
@@ -165,7 +174,7 @@ resource "kubernetes_secret" "langfuse" {
     "postgres-password"   = random_password.postgres_password.result
     "salt"                = random_bytes.salt.base64
     "nextauth-secret"     = random_bytes.nextauth_secret.base64
-    "clickhouse-password" = random_password.clickhouse_password.result
+    "clickhouse-password" = local.deploy_clickhouse ? random_password.clickhouse_password.result : var.external_clickhouse_password
     "encryption_key"      = var.use_encryption_key ? random_bytes.encryption_key[0].hex : ""
   }
 }
@@ -186,7 +195,15 @@ resource "helm_release" "langfuse" {
   depends_on = [
     kubernetes_secret.langfuse,
     google_service_account.langfuse,
+    helm_release.clickhouse,
   ]
+
+  lifecycle {
+    precondition {
+      condition     = var.external_clickhouse == null || var.external_clickhouse_password != ""
+      error_message = "external_clickhouse_password must be set when external_clickhouse is configured."
+    }
+  }
 
   timeout = 1800 # Increase timeout to 15 minutes
 }

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,88 @@ variable "deletion_protection" {
   default     = true
 }
 
+variable "clickhouse_replicas" {
+  description = "Number of ClickHouse replicas (single shard). The default of 3 provides a highly available setup. Only used when ClickHouse is deployed in-cluster."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.clickhouse_replicas >= 1
+    error_message = "clickhouse_replicas must be at least 1."
+  }
+}
+
+variable "clickhouse_keeper_replicas" {
+  description = "Number of ClickHouse Keeper replicas. Must be an odd number to maintain quorum. Only used when ClickHouse is deployed in-cluster."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = contains([1, 3, 5], var.clickhouse_keeper_replicas)
+    error_message = "clickhouse_keeper_replicas must be 1, 3 or 5."
+  }
+}
+
+variable "clickhouse_storage_size" {
+  description = "Size of the persistent volume of each ClickHouse replica"
+  type        = string
+  default     = "100Gi"
+}
+
+variable "clickhouse_keeper_storage_size" {
+  description = "Size of the persistent volume of each ClickHouse Keeper replica"
+  type        = string
+  default     = "10Gi"
+}
+
+variable "clickhouse_storage_class" {
+  description = "StorageClass used for the ClickHouse and ClickHouse Keeper volumes"
+  type        = string
+  default     = "premium-rwo"
+}
+
+variable "clickhouse_resources" {
+  description = "Resource requests for each ClickHouse replica. On GKE Autopilot the limits default to the requests."
+  type = object({
+    cpu    = optional(string, "2")
+    memory = optional(string, "8Gi")
+  })
+  default = {}
+}
+
+variable "clickhouse_operator_chart_version" {
+  description = "Version of the ClickHouse operator and ClickHouse cluster Helm charts (kept in lockstep)"
+  type        = string
+  default     = "0.0.7"
+}
+
+variable "cert_manager_chart_version" {
+  description = "Version of the cert-manager Helm chart. cert-manager issues the certificates for the ClickHouse operator admission webhooks."
+  type        = string
+  default     = "v1.21.0"
+}
+
+variable "external_clickhouse" {
+  description = "Use an external ClickHouse deployment (e.g. ClickHouse Cloud) instead of deploying ClickHouse into the GKE cluster. Set external_clickhouse_password as well. Prefix the host with https:// to connect via HTTPS. The defaults match ClickHouse Cloud; set cluster_enabled = false for ClickHouse Cloud on Azure or single-node deployments."
+  type = object({
+    host            = string
+    http_port       = optional(number, 8443)
+    native_port     = optional(number, 9440)
+    username        = optional(string, "default")
+    database        = optional(string, "default")
+    cluster_enabled = optional(bool, true)
+    migration_ssl   = optional(bool, true)
+  })
+  default = null
+}
+
+variable "external_clickhouse_password" {
+  description = "Password for the external ClickHouse user. Required when external_clickhouse is set."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "langfuse_chart_version" {
   description = "Version of the Langfuse Helm chart to deploy"
   type        = string
@@ -123,7 +205,7 @@ variable "create_dns_zone" {
   type        = bool
   default     = true
 }
-  
+
 variable "ssl_certificate_name" {
   description = "Name of an existing SSL certificate to use. If not provided, a managed certificate will be created."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -24,7 +24,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 2.7" # OCI registry support is required for the ClickHouse operator charts
     }
   }
 }


### PR DESCRIPTION
Replace the Bitnami ClickHouse subchart bundled with the Langfuse Helm chart with a ClickHouse cluster managed by the official ClickHouse Kubernetes operator. This removes all Bitnami container images from the deployment; the previous defaults pulled frozen bitnamilegacy/clickhouse and bitnamilegacy/zookeeper images that no longer receive security patches.

The module now installs cert-manager (required for the operator's admission webhook certificates), the ClickHouse operator, and a ClickHouseCluster plus KeeperCluster rendered through the official cluster chart. The operator names the cluster "default" in remote_servers, matching the cluster name expected by the Langfuse migrations, so ON CLUSTER DDL works unchanged. The deployment is sized via the new clickhouse_replicas, clickhouse_resources, clickhouse_storage_size, clickhouse_storage_class, clickhouse_keeper_replicas, and clickhouse_keeper_storage_size variables.

Additionally, the new external_clickhouse and
external_clickhouse_password inputs allow bringing your own ClickHouse (e.g. ClickHouse Cloud) instead of the in-cluster deployment, skipping cert-manager and the operator entirely.

BREAKING CHANGE: the operator-managed ClickHouse starts empty. Existing installations must migrate their data from the Bitnami-based ClickHouse manually (see README). The helm provider requirement was raised to
>= 2.7 for OCI registry support.