### PR TITLE
feat!: Langfuse v4 via Helm chart v2, external ClickHouse support, explicit app_version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly run against freshly resolved providers, to catch provider
+    # releases that break the module even without any code change.
+    - cron: "23 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: terraform fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - run: terraform fmt -check -diff -recursive
+
+  validate:
+    name: validate (${{ matrix.working-directory }}, TF ${{ matrix.terraform }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Oldest supported Terraform (required_version >= 1.3) and latest.
+        terraform: ["1.3.10", "latest"]
+        working-directory: [".", "examples/quickstart", "examples/external-clickhouse"]
+    defaults:
+      run:
+        working-directory: ${{ matrix.working-directory }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+      - run: terraform init -backend=false -input=false
+      - run: terraform validate

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,155 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:0qkP2yFo87EamHXoV0cK2w6hADP2grd+ZfzAixUPDSw=",
+    "h1:22CAxZ/tGKrnH+5+Cg3DM18S/OvpJZrVMRzp3A40h7Y=",
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:Jw+wqWmsOFONn1I4BVShIkywBAu25VXfTvPBiQJRYYA=",
+    "h1:LxtuVWb0Y6r8I3RsQ8dgXozVzeG1rzFDnCav5EkZCoc=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "h1:ULGxKibTy8Z9F3roMLNFiPgw+MDs7FYuOdiy+Oispi8=",
+    "h1:WO2Jt6hHnY9lvpUdUdhnZ318vq4xPq3R4WYmQ2u7QpU=",
+    "h1:YS1XbzFYWp1xFGo8XyI6TrDrKoz4Ka4CVaeTpPI6xOY=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.7"
+  hashes = [
+    "h1:+NIiFaAqUKl8JBJNk11tfXE4reXce5e3D3V0MOl7/SI=",
+    "h1:/1qQSZBcGfGdSJ1PVDIIRLHF6cCNQDpFnZHA8Z1h5Hg=",
+    "h1:69PnHoYrrDrm7C8+8PiSvRGPI55taqL14SvQR/FGM+g=",
+    "h1:CaN+iT1/mgn062wIkmcZyqhIQEvUQYpGcBYZ7Y7sM84=",
+    "h1:RMCFME+dnIAfqWesdTwaktFf5TCa9shMDtlLWwpJjAw=",
+    "h1:ShIag7wqd5Rs+zYpVMpjAh+T0ozr4XGYfSTKWqceQBY=",
+    "h1:WX5D6JJke4iG8ecGoUt1Gml/ggLHTFhswesyQqxKKG0=",
+    "h1:gy5bFfc81+K/Mi5KRQ6LfRJmgyaTxJnLTzDK+OYJAQg=",
+    "h1:kzDwclZLK5tIKJo3ATWM7a5ODmeczfWkvQDZkr9dVro=",
+    "h1:ojHGbVqPy4ShrUnNL7jif6AnEwgc8vC8sP7f37/VBC8=",
+    "zh:02690815e35131a42cb9851f63a3369c216af30ad093d05b39001d43da04b56b",
+    "zh:27a62f12b29926387f4d71aeeee9f7ffa0ccb81a1b6066ee895716ad050d1b7a",
+    "zh:2d0a5babfa73604b3fefc9dab9c87f91c77fce756c2e32b294e9f1290aed26c0",
+    "zh:3976400ceba6dda4636e1d297e3097e1831de5628afa534a166de98a70d1dcbe",
+    "zh:54440ef14f342b41d75c1aded7487bfcc3f76322b75894235b47b7e89ac4bfa4",
+    "zh:6512e2ab9f2fa31cbb90d9249647b5c5798f62eb1215ec44da2cdaa24e38ad25",
+    "zh:795f327ca0b8c5368af0ed03d5d4f6da7260692b4b3ca0bd004ed542e683464d",
+    "zh:ba659e1d94f224bc3f1fd34cbb9d2663e3a8e734108e5a58eb49eda84b140978",
+    "zh:c5c8575c4458835c2acbc3d1ed5570589b14baa2525d8fbd04295c097caf41eb",
+    "zh:e0877a5dac3de138e61eefa26b2f5a13305a17259779465899880f70e11314e0",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:3VVgWmwdwXFT54fjrplnq+N4+4LZ3ZeLHAlr/0jhPiA=",
+    "h1:9LfHMXiMOboc6PhcEEelKjA3VL94l3MCj7RlbKO1PQM=",
+    "h1:AkW6iAcMGHS+P2BIc2nvQe3PZCHtDL4m6+80tEDLge0=",
+    "h1:HGkB9bCmUqMRcR5/bAUOSqPBsx6DAIEnbT1fZ8vzI78=",
+    "h1:eCV78xGlh9eay+62U4gAgCEMohuiBJXN9XTIZNn+rX4=",
+    "h1:ems+O2dA7atxMWpbtqIrsH7Oa+u+ERWSfpMaFnZPbh0=",
+    "h1:iEDf790HE0h3kz58zfj5IhTVODCDqWF1hISPHz210Uw=",
+    "h1:nY7J9jFXcsRINog0KYagiWZw1GVYF9D2JmtIB7Wnrao=",
+    "h1:yw6JHRONXmiTumaQfJBxl1ierFnNNT/Qio8+ttfMcG4=",
+    "zh:1096b41c4e5b2ee6c1980916fb9a8579bc1892071396f7a9432be058aabf3cbc",
+    "zh:2959fde9ae3d1deb5e317df0d7b02ea4977951ee6b9c4beb083c148ca8f3681c",
+    "zh:5082f98fcb3389c73339365f7df39fc6912bf2bd1a46d5f97778f441a67fd337",
+    "zh:620fd5d0fbc2d7a24ac6b420a4922e6093020358162a62fa8cbd37b2bac1d22e",
+    "zh:7f47c2de179bba35d759147c53082cad6c3449d19b0ec0c5a4ca8db5b06393e1",
+    "zh:89c3aa2a87e29febf100fd21cead34f9a4c0e6e7ae5f383b5cef815c677eb52a",
+    "zh:96eecc9f94938a0bc35b8a63d2c4a5f972395e44206620db06760b730d0471fc",
+    "zh:e15567c1095f898af173c281b66bffdc4f3068afdd9f84bb5b5b5521d9f29584",
+    "zh:ecc6b912629734a9a41a7cf1c4c73fb13b4b510afc9e7b2e0011d290bcd6d77f",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:8EQU5KSxezcjo/phRSe69rDOI0lk4pSaggj7FsskYp8=",
+    "h1:Lw9im2VBBJQ3RyAbHPQ0rcvcmmcZWm3x+kIOpN+Tv9s=",
+    "h1:U8KXqGCoNI9/guYbTvzgdtVk3fRthoG0UXwm1JoEpIs=",
+    "h1:YXaVd4p6qXPPVaxIBaIDNXmBwT02ZqDn0qD+tYpw8sA=",
+    "h1:cOpc03fphEt/G9Rfc4jLL/fW0D7tgvlXqiDKPF4vuww=",
+    "h1:g09RR7T1xWkeGrZwWvWMT9ncJrFGr1k3CBD585UmO7w=",
+    "h1:gGDdPPibmw2EWROx+sh1RGLjR5+nPwZyrf6/N9jXfeM=",
+    "h1:haE7/nXCOhXKP4oXeEnER3t5CaVQWqujz4nBnpeTUv4=",
+    "h1:ieSVpfZS2lKuMr05ph0QsOVpCzg7uk3cgKBaXR+Ikug=",
+    "h1:ig2s1IS9IzehorRjvVAnKIsUUj8fkgyxct1L/kswcc4=",
+    "h1:j3lS+ZEERFnoab8t1ppDrScGVP/cgWbzlCrEYKTCXYw=",
+    "h1:lxezrKmOiQIySHAM+os8qLVq7hqufDr8h3Hpzvsk+78=",
+    "h1:lzRqBJAG+NETxHbEZUJ/YP3RMEjZBinTX7VmgH3lw60=",
+    "h1:tdSNWK5ApqUsgbdYieyeYLTu6nIZUV3hR1oFqUfAuGo=",
+    "h1:xedet8yH/zI2CfdxsGlK0nlFWc/Bp61yrWsEa3fHB8g=",
+    "zh:03f1114cc20b8913523735ab76e0f0a2b16ce13c92923a53304bf85f07fc0dbc",
+    "zh:105b678ee72322a3067f105d7e05e940f6143238f377f6e87ff4ec909246ac2a",
+    "zh:55f3bbf13ea18cbace61a706566a80f25f33fe2b1780b6f3d7b582af2a05b6d2",
+    "zh:63adf996db48f082f7a6351eb485e219cd88795fc71e6ec60a837263ab0d2cb1",
+    "zh:7e99550738a4e3cc68b8a467714b0d69371025fe95e3326d5323d026d55653e9",
+    "zh:8342b54af3a18a37e075eeae61be57f4de2ba71b35d95c5075d402dd2c1f289d",
+    "zh:83ee18e32ac9dd5fc91298554b7c4cfa4c3a1db50f4c797945637cc93c0844ae",
+    "zh:993ecc0adbf6bd535a59fbc9b735d8c33950e6f6eb5e621d750da9b71d65d80a",
+    "zh:ad722bc59d4edbf1415e827fc007c0efe6e0e9462d5568bae20b34be1058a261",
+    "zh:ae9448e1f87b2f9a6c5197a0e9862162ec6b137cb3a3835e11522995d8939e7c",
+    "zh:bc9cdd3aac784f759125c6627f6f6416e8726a1c184eb9cf3e55b9edbc94c627",
+    "zh:c8e35b89572ba1c40a9b20022e033a3395fb8d42e7604d50c900f193ba10382e",
+    "zh:e2deaa8a9975ef81d9f62baed12c41286918b0a10908e0e031f13f69a3b730a1",
+    "zh:ee39707557210a0ab1098aa357d2cdfe502e5a312d0dbdffb09d08facc4d3fc5",
+    "zh:f81afe4eb63e8aa9e0ea71be6c990f0dc69cb360e7191c0742a991f4a5081b64",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/tls" {
+  version     = "4.3.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:+15bx0zcnqLz534Cbb8IC+FHMqfG55ELn+PxrQDA4gc=",
+    "h1:CzxZKtqwgNLbLx29KpIG8H3jOQFRkXCerkDRafS6PCg=",
+    "h1:EF8ln/osHphljZ9LNlqUICducYCjUq+PSaC2wBZM6cA=",
+    "h1:GizReb5vbh71HnhHlGphHhVFj3ghwAaC2MKqb2d8Ye8=",
+    "h1:O5oOot0y1MLb/j2gXVAOd20bPzM0daZyqgCk4kHbihg=",
+    "h1:SGBiqFFxGryTOiaNNWlC7CCba1hjSsSwcJeg6rOLJrc=",
+    "h1:UAV4fX41sizZ4U+FavGu3Fkgm4g7k8JD7BqBuhjMZ7o=",
+    "h1:ZxKvDInYHzss9rv75M778pInFm08ME6hY31XMyFP4IA=",
+    "h1:fpHTjAZkKqg+bRAiHmNzsMtYOPleAuK0hpdJxTLPtJE=",
+    "h1:hC3YGicct3gfUaMeY/Ci1MbS0ieDr6POkU8sudjkwKE=",
+    "h1:jJrKC+VUBdAAfBlcB06mNmlGskdd+MGoQI34hsMLItY=",
+    "h1:mmFJoeY9KBishP/zH8vvtpDekcqiYucgUGUnErhECAY=",
+    "h1:uMVBRi+9fgKgigHapewZE/BPiu/GfPvXlor/N7glFTk=",
+    "h1:xCRJdZECen3k+Qct+nUrUkUG5wpbeSiGHQGIJpgdkxg=",
+    "h1:xX++0TgL6lEWjSs33i3gI07CL1uIcOvUSweNkhvXK78=",
+    "zh:07bb8c6e64124dada7dff57a38a46f2f323b3fd77920404c0c550293d1cf6188",
+    "zh:0b3bfda2df39c52f1c5452d05cf3107bedd5d20ab6977c90ede540c695fb6c3e",
+    "zh:110a055289f0400a63ac172bedb0e671d059b7a5ba22d4a3f5f246ccac0ad676",
+    "zh:15e532d8c711377499dece832e60170a8bef39830125b8154f4bda81d9721d29",
+    "zh:22ca65d96e9fc1be5605372d855c9e1eba2d86d510f7ac8593968f5649435e47",
+    "zh:36df38dfd03e8c1298c5704fd85e28b69a3927ed0b339f9628d0b56dac99c6b5",
+    "zh:429e2bfcb81656e1fe90b7b284767d1453c1a4100b16d27e4b29c34aa12f0ce1",
+    "zh:5b6679953065f0279bf018426c6fb06dd93a851a7a9369f2e3a1fec5bc417e83",
+    "zh:6a72c88d5aa945ddb32041350755377c96681563136decfe7e05c7cdea7988f1",
+    "zh:6f05757c50da9f8354a735b5756bd63a71126fcd142129525b90c56bfd081d61",
+    "zh:751703b7a4d40c3a111c4ed0d5da3ec91c14f880faf6f010a5000a2eb5366011",
+    "zh:87a5279e61b8198798a2fe86cfe3b74e5340bb486f4e148bb5b4d46f860cf1db",
+    "zh:942af95e9fd73327a7e9ab0803c4d701b782ddacd78c9b7ce9c91e38b3051522",
+    "zh:a457d0efea3c404178a182d240ba21cdeb0c620ffabeeb9a8977b024a85e1360",
+    "zh:d5eac8f4f0ae1ff41cbcc1008e6a74a8491dc27f4c6e5a0c32c5c4b6ef2e4087",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ module "langfuse" {
   subnetwork_cidr = "10.0.0.0/16"
 
   # Optional: Configure the Langfuse Helm chart version
-  langfuse_chart_version = "1.5.14"
+  langfuse_chart_version = "2.0.0"
+
+  # Optional: Pin the Langfuse application version. Defaults to the latest
+  # release at the time this module version was published.
+  app_version = "4.14.0"
 }
 
 provider "kubernetes" {
@@ -109,10 +113,61 @@ This module creates a complete Langfuse stack with the following components:
 - Cloud SQL PostgreSQL instance
 - Cloud Memorystore Redis instance
 - Cloud Storage bucket for storage
+- ClickHouse cluster managed by the official [ClickHouse Kubernetes operator](https://github.com/ClickHouse/clickhouse-operator) (including ClickHouse Keeper and cert-manager), or optionally an external ClickHouse such as ClickHouse Cloud
 - TLS certificates and Cloud DNS configuration
 - Required IAM roles and firewall rules
 - GKE Ingress Controller for ingress
 - Filestore CSI Driver for persistent storage
+
+## Langfuse version
+
+The module deploys the Langfuse Helm chart v2 (`langfuse_chart_version`), which ships [Langfuse v4](https://langfuse.com/docs/v4). The Langfuse application version is pinned explicitly through the `app_version` variable, which defaults to the latest Langfuse release at the time the module version was published. To upgrade Langfuse, set `app_version` to a newer [release](https://github.com/langfuse/langfuse/releases):
+
+```hcl
+module "langfuse" {
+  # ...
+  app_version = "4.14.0"
+}
+```
+
+## ClickHouse
+
+By default the Langfuse Helm chart v2 deploys a ClickHouse cluster into the GKE cluster through the official [ClickHouse Kubernetes operator](https://github.com/ClickHouse/clickhouse-operator) (`ClickHouseCluster` and `KeeperCluster` resources). To support this, the module installs:
+
+- [cert-manager](https://cert-manager.io/) (required by the operator to issue its admission webhook certificates)
+- The ClickHouse operator (`oci://ghcr.io/clickhouse/clickhouse-operator-helm`)
+
+The deployment can be sized with the `clickhouse_replicas`, `clickhouse_resources`, `clickhouse_storage_size`, `clickhouse_storage_class`, `clickhouse_keeper_replicas`, and `clickhouse_keeper_storage_size` variables.
+
+### External ClickHouse (bring your own)
+
+To use an existing ClickHouse instead — for example [ClickHouse Cloud](https://clickhouse.com/cloud) — set `external_clickhouse`. The module then skips cert-manager, the operator, and the in-cluster ClickHouse entirely. See [examples/external-clickhouse](examples/external-clickhouse/external-clickhouse.tf) for a full example.
+
+```hcl
+module "langfuse" {
+  source = "github.com/langfuse/langfuse-terraform-gcp"
+
+  domain = "langfuse.example.com"
+
+  external_clickhouse = {
+    host = "https://abc123.europe-west4.gcp.clickhouse.cloud"
+    # Defaults: http_port = 8443, native_port = 9440, username = "default",
+    # database = "default", cluster_enabled = true, migration_ssl = true
+  }
+  external_clickhouse_password = var.clickhouse_password
+}
+```
+
+Set `cluster_enabled = false` for ClickHouse Cloud on Azure or for single-node deployments. Make sure the GKE cluster can reach the external ClickHouse (for ClickHouse Cloud, check the IP allowlist or use Private Service Connect).
+
+### Migrating from module versions <= 0.3.x
+
+Earlier versions of this module deployed Langfuse v3 with the Bitnami-based Helm chart v1, which ran ClickHouse (and ZooKeeper) as a Bitnami subchart. **Upgrading is a breaking change**: the operator-managed ClickHouse starts empty, and the Helm chart refuses a raw in-place `helm upgrade` that would replace leftover Bitnami volumes. Existing installations must migrate in two steps:
+
+1. Migrate the chart deployment (copying the ClickHouse data) following the [chart v1 → v2 migration guide](https://github.com/langfuse/langfuse-k8s/tree/main/examples/upgrade-v1-to-v2).
+2. Upgrade the application following the [Langfuse v3 → v4 upgrade guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+New installations are unaffected. If you need to stay on the Bitnami-based deployment for now, pin this module to `0.3.x`.
 
 ## Additional Environment Variables
 
@@ -160,11 +215,11 @@ module "langfuse" {
 
 | Name        | Version |
 |-------------|---------|
-| terraform   | >= 1.0  |
+| terraform   | >= 1.3  |
 | google      | >= 5.0  |
 | google-beta | >= 5.0  |
 | kubernetes  | >= 2.10 |
-| helm        | >= 2.5  |
+| helm        | >= 2.7  |
 
 ## Providers
 
@@ -173,7 +228,7 @@ module "langfuse" {
 | google      | >= 5.0  |
 | google-beta | >= 5.0  |
 | kubernetes  | >= 2.10 |
-| helm        | >= 2.5  |
+| helm        | >= 2.7  |
 | random      | >= 3.0  |
 | tls         | >= 3.0  |
 
@@ -204,6 +259,7 @@ module "langfuse" {
 | kubernetes_secret.langfuse                  | resource |
 | helm_release.ingress_nginx                  | resource |
 | helm_release.cert_manager                   | resource |
+| helm_release.clickhouse_operator            | resource |
 | random_password.database                    | resource |
 | tls_private_key.langfuse                    | resource |
 
@@ -222,7 +278,18 @@ module "langfuse" {
 | cache_tier                          | The service tier of the instance                                                                                                                                                                          | string       | "STANDARD_HA"           |    no    |
 | cache_memory_size_gb                | Redis memory size in GB                                                                                                                                                                                   | number       | 1                       |    no    |
 | deletion_protection                 | Whether or not to enable deletion_protection on data sensitive resources                                                                                                                                  | bool         | true                    |    no    |
-| langfuse_chart_version              | Version of the Langfuse Helm chart to deploy                                                                                                                                                              | string       | "1.5.14"                |    no    |
+| clickhouse_replicas                 | Number of ClickHouse replicas (single shard). The default of 3 provides a highly available setup. Only used when ClickHouse is deployed in-cluster.                                                       | number       | 3                       |    no    |
+| clickhouse_keeper_replicas          | Number of ClickHouse Keeper replicas. Must be 1, 3 or 5 to maintain quorum. Only used when ClickHouse is deployed in-cluster.                                                                             | number       | 3                       |    no    |
+| clickhouse_storage_size             | Size of the persistent volume of each ClickHouse replica                                                                                                                                                  | string       | "100Gi"                 |    no    |
+| clickhouse_keeper_storage_size      | Size of the persistent volume of each ClickHouse Keeper replica                                                                                                                                           | string       | "10Gi"                  |    no    |
+| clickhouse_storage_class            | StorageClass used for the ClickHouse and ClickHouse Keeper volumes                                                                                                                                        | string       | "premium-rwo"           |    no    |
+| clickhouse_resources                | Resource requests and limits for each ClickHouse replica                                                                                                                                                  | object       | { cpu = "2", memory = "8Gi" } | no |
+| clickhouse_operator_chart_version   | Version of the ClickHouse operator Helm chart. The default matches the version the Langfuse Helm chart is tested against.                                                                                 | string       | "0.0.5"                 |    no    |
+| cert_manager_chart_version          | Version of the cert-manager Helm chart. cert-manager issues the certificates for the ClickHouse operator admission webhooks.                                                                              | string       | "v1.20.2"               |    no    |
+| external_clickhouse                 | Use an external ClickHouse deployment (e.g. ClickHouse Cloud) instead of deploying ClickHouse into the GKE cluster. See [External ClickHouse](#external-clickhouse-bring-your-own).                       | object       | null                    |    no    |
+| external_clickhouse_password        | Password for the external ClickHouse user. Required when external_clickhouse is set.                                                                                                                      | string       | ""                      |    no    |
+| langfuse_chart_version              | Version of the Langfuse Helm chart to deploy                                                                                                                                                              | string       | "2.0.0"                 |    no    |
+| app_version                         | Langfuse application version (Docker image tag) to deploy. Defaults to the latest Langfuse release at the time this module version was published.                                                          | string       | "4.14.0"                |    no    |
 | additional_env                      | Additional environment variables to add to the Langfuse container. Supports both direct values and Kubernetes valueFrom references (secrets, configMaps). See examples/additional-env for usage examples. | list(object) | []                      |    no    |
 | create_dns_zone                     | Whether to create a Google Cloud DNS managed zone. Set to `false` if you manage DNS externally.                                                                                                           | bool         | true                    |    no    |
 | provision_static_ip                 | Whether to provision a static global IP for the Ingress. Set to `true` if you need a stable IP for DNS configuration before deployment.                                                                   | bool         | false                   |    no    |

--- a/README.md
+++ b/README.md
@@ -61,26 +61,29 @@ provider "helm" {
 }
 ```
 
-2. Apply the DNS zone and the GKE Cluster. This avoids an error around missing dependencies on the [kubernetes_manifest](https://github.com/hashicorp/terraform-provider-kubernetes/issues/1775).
+3. Apply the DNS zone and the GKE Cluster.
 
 ```bash
 terraform init
 terraform apply --target module.langfuse.google_dns_managed_zone.this --target module.langfuse.google_container_cluster.this
 ```
 
-3. Set up the Nameserver delegation on your DNS provider. You can find the nameservers using the following command. Replace `langfuse` with your zone name, e.g. `langfuse-example-com`.
+> [!IMPORTANT]
+> **The two-stage apply is the supported installation flow, not a workaround.** The `kubernetes` and `helm` providers are configured from this module's outputs, so the GKE cluster must exist before Terraform can plan any Kubernetes or Helm resources (see [kubernetes_manifest](https://github.com/hashicorp/terraform-provider-kubernetes/issues/1775)). This also applies when you embed this module in a larger Terraform configuration: plan on creating the cluster in a first targeted apply (or a separate pipeline stage) before applying the full stack.
+
+4. Set up the Nameserver delegation on your DNS provider. You can find the nameservers using the following command. Replace `langfuse` with your zone name, e.g. `langfuse-example-com`.
 
 ```bash
 $ gcloud dns managed-zones describe langfuse --format="get(nameServers)"
 ```
 
-4. Apply the full stack
+5. Apply the full stack
 
 ```bash
 terraform apply
 ```
 
-5. Start using Langfuse by navigating to `https://<domain>` in your browser.
+6. Start using Langfuse by navigating to `https://<domain>` in your browser.
 
 ### Known issues
 
@@ -162,7 +165,9 @@ Set `cluster_enabled = false` for ClickHouse Cloud on Azure or for single-node d
 
 ### Migrating from module versions <= 0.3.x
 
-Earlier versions of this module deployed Langfuse v3 with the Bitnami-based Helm chart v1, which ran ClickHouse (and ZooKeeper) as a Bitnami subchart. **Upgrading is a breaking change**: the operator-managed ClickHouse starts empty, and the Helm chart refuses a raw in-place `helm upgrade` that would replace leftover Bitnami volumes. Existing installations must migrate in two steps:
+This module version is a **clean Langfuse v4 installation based on v2.0.0 of the Langfuse Helm chart**. It does not migrate existing deployments.
+
+Earlier versions of this module deployed Langfuse v3 with the Bitnami-based Helm chart v1, which ran ClickHouse (and ZooKeeper) as a Bitnami subchart. The operator-managed ClickHouse starts empty, and the Helm chart refuses a raw in-place `helm upgrade` that would replace leftover Bitnami volumes. If you upgrade an existing installation, you must perform the migration steps **manually, outside of Terraform**, before switching the module version:
 
 1. Migrate the chart deployment (copying the ClickHouse data) following the [chart v1 → v2 migration guide](https://github.com/langfuse/langfuse-k8s/tree/main/examples/upgrade-v1-to-v2).
 2. Upgrade the application following the [Langfuse v3 → v4 upgrade guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).

--- a/clickhouse.tf
+++ b/clickhouse.tf
@@ -6,3 +6,60 @@ resource "random_password" "clickhouse_password" {
   min_upper   = 1
   min_numeric = 1
 }
+
+locals {
+  # Deploy ClickHouse into the GKE cluster unless an external one is configured
+  deploy_clickhouse = var.external_clickhouse == null
+}
+
+# cert-manager issues the TLS certificates for the ClickHouse operator's
+# admission webhooks. Only required while ClickHouse runs in-cluster.
+resource "helm_release" "cert_manager" {
+  count = local.deploy_clickhouse ? 1 : 0
+
+  name             = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  version          = var.cert_manager_chart_version
+  namespace        = "cert-manager"
+  create_namespace = true
+
+  # Explicit resource requests to avoid the GKE Autopilot defaults of
+  # 500m CPU / 2Gi memory per container
+  values = [<<EOT
+crds:
+  enabled: true
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+webhook:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+cainjector:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+EOT
+  ]
+}
+
+# Official ClickHouse Kubernetes operator. The Langfuse Helm chart v2 renders
+# ClickHouseCluster and KeeperCluster resources that this operator reconciles.
+# Both CRD sets (cert-manager and the operator) must exist before the Langfuse
+# chart is installed.
+resource "helm_release" "clickhouse_operator" {
+  count = local.deploy_clickhouse ? 1 : 0
+
+  name             = "clickhouse-operator"
+  repository       = "oci://ghcr.io/clickhouse"
+  chart            = "clickhouse-operator-helm"
+  version          = var.clickhouse_operator_chart_version
+  namespace        = "clickhouse-operator-system"
+  create_namespace = true
+
+  depends_on = [helm_release.cert_manager]
+}

--- a/clickhouse.tf
+++ b/clickhouse.tf
@@ -45,6 +45,10 @@ cainjector:
       memory: 128Mi
 EOT
   ]
+
+  # Autopilot provisions nodes on demand; first installs can exceed the
+  # default 300s while the three cert-manager deployments come up.
+  timeout = 600
 }
 
 # Official ClickHouse Kubernetes operator. The Langfuse Helm chart v2 renders
@@ -60,6 +64,11 @@ resource "helm_release" "clickhouse_operator" {
   version          = var.clickhouse_operator_chart_version
   namespace        = "clickhouse-operator-system"
   create_namespace = true
+
+  # Waiting (helm provider default) matters here: the operator deployment only
+  # becomes ready once cert-manager has issued its webhook certificate, and the
+  # Langfuse chart requires the operator CRDs and webhook to exist.
+  timeout = 600
 
   depends_on = [helm_release.cert_manager]
 }

--- a/examples/external-clickhouse/external-clickhouse.tf
+++ b/examples/external-clickhouse/external-clickhouse.tf
@@ -1,0 +1,46 @@
+# Deploys Langfuse against an external ClickHouse (e.g. ClickHouse Cloud)
+# instead of running ClickHouse inside the GKE cluster. With an external
+# ClickHouse configured, the module does not install cert-manager, the
+# ClickHouse operator, or an in-cluster ClickHouse.
+
+variable "clickhouse_password" {
+  description = "Password of the external ClickHouse user"
+  type        = string
+  sensitive   = true
+}
+
+module "langfuse" {
+  source = "../.."
+
+  domain = "langfuse.example.com"
+
+  # ClickHouse Cloud connection. The defaults match ClickHouse Cloud:
+  # HTTPS on port 8443 and the TLS native protocol on port 9440.
+  external_clickhouse = {
+    host = "https://abc123.europe-west4.gcp.clickhouse.cloud"
+
+    # Uncomment for ClickHouse Cloud on Azure or single-node deployments:
+    # cluster_enabled = false
+
+    # For a self-managed ClickHouse without TLS instead:
+    # host          = "clickhouse.internal.example.com"
+    # http_port     = 8123
+    # native_port   = 9000
+    # migration_ssl = false
+  }
+  external_clickhouse_password = var.clickhouse_password
+}
+
+provider "kubernetes" {
+  host                   = module.langfuse.cluster_host
+  cluster_ca_certificate = module.langfuse.cluster_ca_certificate
+  token                  = module.langfuse.cluster_token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.langfuse.cluster_host
+    cluster_ca_certificate = module.langfuse.cluster_ca_certificate
+    token                  = module.langfuse.cluster_token
+  }
+}

--- a/examples/quickstart/quickstart.tf
+++ b/examples/quickstart/quickstart.tf
@@ -16,14 +16,18 @@ module "langfuse" {
   # Optional: Configure the database instances
   database_instance_tier              = "db-perf-optimized-N-2"
   database_instance_availability_type = "REGIONAL"
-  database_instance_edition = "ENTERPRISE_PLUS"
+  database_instance_edition           = "ENTERPRISE_PLUS"
 
   # Optional: Configure the cache
   cache_tier           = "STANDARD_HA"
   cache_memory_size_gb = 1
 
   # Optional: Configure the Langfuse Helm chart version
-  langfuse_chart_version = "1.5.14"
+  langfuse_chart_version = "2.0.0"
+
+  # Optional: Pin the Langfuse application version (defaults to the latest
+  # release at the time this module version was published)
+  app_version = "4.14.0"
 }
 
 provider "kubernetes" {

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -1,6 +1,8 @@
 locals {
-  langfuse_values   = <<EOT
+  langfuse_values = <<EOT
 langfuse:
+  image:
+    tag: ${jsonencode(var.app_version)}
   salt:
     secretKeyRef:
       name: ${kubernetes_secret.langfuse.metadata[0].name}
@@ -56,10 +58,6 @@ postgresql:
     existingSecret: ${kubernetes_secret.langfuse.metadata[0].name}
     secretKeys:
       userPasswordKey: postgres-password
-clickhouse:
-  auth:
-    existingSecret: ${kubernetes_secret.langfuse.metadata[0].name}
-    existingSecretKey: clickhouse-password
 redis:
   deploy: false
   host: ${google_redis_instance.this.host}
@@ -81,6 +79,56 @@ s3:
   mediaUpload:
     prefix: "media/"
 EOT
+
+  # In-cluster ClickHouse: the Langfuse Helm chart v2 renders ClickHouseCluster
+  # and KeeperCluster resources reconciled by the ClickHouse operator (see
+  # clickhouse.tf).
+  clickhouse_internal_values = !local.deploy_clickhouse ? "" : <<EOT
+clickhouse:
+  deploy: true
+  auth:
+    existingSecret: ${kubernetes_secret.langfuse.metadata[0].name}
+    existingSecretKey: clickhouse-password
+  cluster:
+    replicas: ${var.clickhouse_replicas}
+    storage:
+      size: ${var.clickhouse_storage_size}
+      className: ${var.clickhouse_storage_class}
+    resources:
+      requests:
+        cpu: ${jsonencode(var.clickhouse_resources.cpu)}
+        memory: ${jsonencode(var.clickhouse_resources.memory)}
+      limits:
+        cpu: ${jsonencode(var.clickhouse_resources.cpu)}
+        memory: ${jsonencode(var.clickhouse_resources.memory)}
+  keeper:
+    replicas: ${var.clickhouse_keeper_replicas}
+    storage:
+      size: ${var.clickhouse_keeper_storage_size}
+      className: ${var.clickhouse_storage_class}
+EOT
+
+  # External ClickHouse: skip the in-cluster deployment and point Langfuse at
+  # the provided instance.
+  clickhouse_external_values = local.deploy_clickhouse ? "" : <<EOT
+clickhouse:
+  deploy: false
+  host: ${jsonencode(var.external_clickhouse.host)}
+  httpPort: ${var.external_clickhouse.http_port}
+  nativePort: ${var.external_clickhouse.native_port}
+  database: ${jsonencode(var.external_clickhouse.database)}
+  cluster:
+    enabled: ${var.external_clickhouse.cluster_enabled}
+  auth:
+    username: ${jsonencode(var.external_clickhouse.username)}
+    existingSecret: ${kubernetes_secret.langfuse.metadata[0].name}
+    existingSecretKey: clickhouse-password
+  migration:
+    ssl: ${var.external_clickhouse.migration_ssl}
+EOT
+
+  clickhouse_values = local.deploy_clickhouse ? local.clickhouse_internal_values : local.clickhouse_external_values
+
   ingress_values    = <<EOT
 langfuse:
   ingress:
@@ -165,7 +213,7 @@ resource "kubernetes_secret" "langfuse" {
     "postgres-password"   = random_password.postgres_password.result
     "salt"                = random_bytes.salt.base64
     "nextauth-secret"     = random_bytes.nextauth_secret.base64
-    "clickhouse-password" = random_password.clickhouse_password.result
+    "clickhouse-password" = local.deploy_clickhouse ? random_password.clickhouse_password.result : var.external_clickhouse_password
     "encryption_key"      = var.use_encryption_key ? random_bytes.encryption_key[0].hex : ""
   }
 }
@@ -179,6 +227,7 @@ resource "helm_release" "langfuse" {
 
   values = concat([
     local.langfuse_values,
+    local.clickhouse_values,
     local.ingress_values,
     local.encryption_values,
   ], var.additional_helm_values)
@@ -186,7 +235,15 @@ resource "helm_release" "langfuse" {
   depends_on = [
     kubernetes_secret.langfuse,
     google_service_account.langfuse,
+    helm_release.clickhouse_operator,
   ]
+
+  lifecycle {
+    precondition {
+      condition     = var.external_clickhouse == null || var.external_clickhouse_password != ""
+      error_message = "external_clickhouse_password must be set when external_clickhouse is configured."
+    }
+  }
 
   timeout = 1800 # Increase timeout to 15 minutes
 }

--- a/redis.tf
+++ b/redis.tf
@@ -1,12 +1,12 @@
 resource "google_redis_instance" "this" {
-  name               = var.name
-  tier               = var.cache_tier
-  memory_size_gb     = var.cache_memory_size_gb
-  region             = data.google_client_config.current.region
-  authorized_network = google_compute_network.this.id
-  connect_mode       = "PRIVATE_SERVICE_ACCESS"
+  name                    = var.name
+  tier                    = var.cache_tier
+  memory_size_gb          = var.cache_memory_size_gb
+  region                  = data.google_client_config.current.region
+  authorized_network      = google_compute_network.this.id
+  connect_mode            = "PRIVATE_SERVICE_ACCESS"
   transit_encryption_mode = "SERVER_AUTHENTICATION"
-  display_name = "${local.tag_name} Redis Instance"
+  display_name            = "${local.tag_name} Redis Instance"
 
   auth_enabled = true
 

--- a/variables.tf
+++ b/variables.tf
@@ -75,10 +75,98 @@ variable "deletion_protection" {
   default     = true
 }
 
+variable "clickhouse_replicas" {
+  description = "Number of ClickHouse replicas (single shard). The default of 3 provides a highly available setup. Only used when ClickHouse is deployed in-cluster."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.clickhouse_replicas >= 1
+    error_message = "clickhouse_replicas must be at least 1."
+  }
+}
+
+variable "clickhouse_keeper_replicas" {
+  description = "Number of ClickHouse Keeper replicas. Must be 1, 3 or 5 to maintain quorum. Only used when ClickHouse is deployed in-cluster."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = contains([1, 3, 5], var.clickhouse_keeper_replicas)
+    error_message = "clickhouse_keeper_replicas must be 1, 3 or 5."
+  }
+}
+
+variable "clickhouse_storage_size" {
+  description = "Size of the persistent volume of each ClickHouse replica"
+  type        = string
+  default     = "100Gi"
+}
+
+variable "clickhouse_keeper_storage_size" {
+  description = "Size of the persistent volume of each ClickHouse Keeper replica"
+  type        = string
+  default     = "10Gi"
+}
+
+variable "clickhouse_storage_class" {
+  description = "StorageClass used for the ClickHouse and ClickHouse Keeper volumes"
+  type        = string
+  default     = "premium-rwo"
+}
+
+variable "clickhouse_resources" {
+  description = "Resource requests and limits for each ClickHouse replica"
+  type = object({
+    cpu    = optional(string, "2")
+    memory = optional(string, "8Gi")
+  })
+  default = {}
+}
+
+variable "clickhouse_operator_chart_version" {
+  description = "Version of the ClickHouse operator Helm chart (oci://ghcr.io/clickhouse/clickhouse-operator-helm). The default matches the version the Langfuse Helm chart is tested against."
+  type        = string
+  default     = "0.0.5"
+}
+
+variable "cert_manager_chart_version" {
+  description = "Version of the cert-manager Helm chart. cert-manager issues the certificates for the ClickHouse operator admission webhooks."
+  type        = string
+  default     = "v1.20.2"
+}
+
+variable "external_clickhouse" {
+  description = "Use an external ClickHouse deployment (e.g. ClickHouse Cloud) instead of deploying ClickHouse into the GKE cluster. Set external_clickhouse_password as well. Prefix the host with https:// to connect via HTTPS. The defaults match ClickHouse Cloud; set cluster_enabled = false for ClickHouse Cloud on Azure or single-node deployments."
+  type = object({
+    host            = string
+    http_port       = optional(number, 8443)
+    native_port     = optional(number, 9440)
+    username        = optional(string, "default")
+    database        = optional(string, "default")
+    cluster_enabled = optional(bool, true)
+    migration_ssl   = optional(bool, true)
+  })
+  default = null
+}
+
+variable "external_clickhouse_password" {
+  description = "Password for the external ClickHouse user. Required when external_clickhouse is set."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "langfuse_chart_version" {
   description = "Version of the Langfuse Helm chart to deploy"
   type        = string
-  default     = "1.5.14"
+  default     = "2.0.0"
+}
+
+variable "app_version" {
+  description = "Langfuse application version (Docker image tag) to deploy, e.g. \"4.14.0\". Defaults to the latest Langfuse release at the time this module version was published. See https://github.com/langfuse/langfuse/releases."
+  type        = string
+  default     = "4.14.0"
 }
 
 variable "additional_helm_values" {
@@ -123,7 +211,7 @@ variable "create_dns_zone" {
   type        = bool
   default     = true
 }
-  
+
 variable "ssl_certificate_name" {
   description = "Name of an existing SSL certificate to use. If not provided, a managed certificate will be created."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     google = {
@@ -24,7 +24,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 2.7" # OCI registry support is required for the ClickHouse operator chart
     }
   }
 }


### PR DESCRIPTION
## Summary

Three changes that together move the module to Langfuse v4 with a stable, explicit interface:

1. **Helm chart v2 / Langfuse v4 by default.** `langfuse_chart_version` now defaults to `2.0.0`. Chart v2 replaces the Bitnami ClickHouse subchart with `ClickHouseCluster`/`KeeperCluster` resources reconciled by the official [ClickHouse Kubernetes operator](https://github.com/ClickHouse/clickhouse-operator). The module installs the two prerequisites (cert-manager with Autopilot-friendly resource requests, and the operator) as `helm_release`s when ClickHouse runs in-cluster; the chart itself renders the ClickHouse/Keeper resources, sized via the new `clickhouse_replicas`, `clickhouse_resources`, `clickhouse_storage_size`, `clickhouse_storage_class`, `clickhouse_keeper_replicas`, and `clickhouse_keeper_storage_size` variables.
2. **External ClickHouse.** New `external_clickhouse` + `external_clickhouse_password` inputs point Langfuse at an existing ClickHouse (e.g. ClickHouse Cloud) instead, skipping cert-manager, the operator, and the in-cluster ClickHouse entirely. Defaults match ClickHouse Cloud (`https://` host, 8443/9440, TLS migrations). See `examples/external-clickhouse`.
3. **Explicit `app_version`.** The Langfuse image tag is now a first-class variable defaulting to the latest release at commit time (`4.14.0`). Upgrading Langfuse becomes a visible one-line diff instead of an implicit chart-appVersion bump.

Supersedes #30: same variable interface, but now that chart v2 renders the operator CRs itself, the module no longer needs its own `clickhouse-cluster-helm` release, and the chart default flips to Langfuse v4 at the same time.

## Breaking changes

- Chart v2 starts an **empty** operator-managed ClickHouse; the chart refuses a raw in-place `helm upgrade` over leftover Bitnami volumes. Existing installations must follow the [chart v1 → v2 migration](https://github.com/langfuse/langfuse-k8s/tree/main/examples/upgrade-v1-to-v2) and then the [Langfuse v3 → v4 upgrade guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4). The README has a migration section.
- Requires Terraform >= 1.3 and helm provider >= 2.7 (OCI charts).

## Test plan

- [x] `tofu validate` passes on the root module, `examples/quickstart`, and the new `examples/external-clickhouse`.
- [x] Chart value paths verified against `langfuse-k8s` `langfuse-2.0.0` (`values.yaml`, `templates/clickhouse/*`, `validations.yaml`).
- [ ] Not applied to a live GCP project from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
