### PR TITLE
ci: fmt and validate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly run against freshly resolved providers, to catch provider
+    # releases that break the module even without any code change.
+    - cron: "23 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: terraform fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - run: terraform fmt -check -diff -recursive
+
+  validate:
+    name: validate (${{ matrix.working-directory }}, TF ${{ matrix.terraform }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Oldest supported Terraform (required_version >= 1.3) and latest.
+        terraform: ["1.3.10", "latest"]
+        working-directory: [".", "examples/quickstart", "examples/external-clickhouse"]
+    defaults:
+      run:
+        working-directory: ${{ matrix.working-directory }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+      - run: terraform init -backend=false -input=false
+      - run: terraform validate

--- a/redis.tf
+++ b/redis.tf
@@ -1,12 +1,12 @@
 resource "google_redis_instance" "this" {
-  name               = var.name
-  tier               = var.cache_tier
-  memory_size_gb     = var.cache_memory_size_gb
-  region             = data.google_client_config.current.region
-  authorized_network = google_compute_network.this.id
-  connect_mode       = "PRIVATE_SERVICE_ACCESS"
+  name                    = var.name
+  tier                    = var.cache_tier
+  memory_size_gb          = var.cache_memory_size_gb
+  region                  = data.google_client_config.current.region
+  authorized_network      = google_compute_network.this.id
+  connect_mode            = "PRIVATE_SERVICE_ACCESS"
   transit_encryption_mode = "SERVER_AUTHENTICATION"
-  display_name = "${local.tag_name} Redis Instance"
+  display_name            = "${local.tag_name} Redis Instance"
 
   auth_enabled = true
 


### PR DESCRIPTION
Stacked on #31 — retarget to `main` once that merges.

## Summary

- `terraform fmt -check` gate (plus the one `fmt` fix in `redis.tf` it required)
- `terraform init -backend=false` + `terraform validate` for the root module and both examples, on a matrix of the oldest supported Terraform (1.3.10, the `required_version >= 1.3` floor) and latest
- a **weekly scheduled run**: because `init` re-resolves provider versions, provider releases that break the module without any code change surface as a red run on `main` instead of in a user's fresh `terraform init`. That is exactly the failure mode the Azure module hit with azurerm 5.x.

Actions are SHA-pinned. No cloud credentials are needed; `validate` never talks to GCP.

Deliberately not included (possible follow-ups): tflint, terraform-docs drift check, and any plan/apply job (needs credentials and a sandbox project).

## Test plan

- [x] `fmt -check -recursive` clean and `validate` green locally for root and both examples (same commands the workflow runs)
- [ ] Matrix run on GitHub-hosted runners happens on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)