### PR TITLE
ci: weekly Langfuse version check and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,8 @@
 name: Release
 
-# Releasing is two steps, because `main` is protected and direct pushes are
-# rejected:
-#
-#   1. Run this workflow manually with the new version. It opens a pull request
-#      that bumps the module version documented in the README.
-#   2. Merge that pull request. The `tag` job then reconciles tags with the
-#      version declared in the README on `main`: it creates and pushes the
-#      matching tag and a GitHub release.
-#
-# The README `?ref=` value is therefore the single source of truth for the
-# module version, and step 2 is idempotent - a README change that does not
-# change the version is a no-op.
+# Run this workflow with the new version to open the release pull request.
+# Merging it publishes the version the README documents, the same way
+# langfuse-k8s releases charts from Chart.yaml on main.
 
 on:
   workflow_dispatch:
@@ -24,142 +15,70 @@ on:
     branches: [main]
     paths: ["README.md"]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
-  group: release
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   prepare:
-    name: Prepare release
+    name: Open release pull request
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Commit the version bump.
+      pull-requests: write # Open the release pull request.
+
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Bump documented module version
-        id: bump
+      - name: Bump the documented module version
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          set -euo pipefail
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Unsupported version format: '$VERSION'" >&2; exit 1; }
+          perl -pi -e 's{\?ref=[^"]+}{?ref=$ENV{VERSION}}g' README.md
+          git diff --quiet -- README.md && { echo "README.md already documents $VERSION" >&2; exit 1; }
+          exit 0
 
-          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'; then
-            echo "::error::'$VERSION' is not a valid version (expected X.Y.Z or X.Y.Z-rc.N)"
-            exit 1
-          fi
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump version to ${{ inputs.version }}"
+          title: "chore: bump version to ${{ inputs.version }}"
+          body: "Merging this creates the `${{ inputs.version }}` tag and publishes a GitHub release."
+          branch: release/${{ inputs.version }}
+          delete-branch: true
 
-          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
-            echo "::error::tag $VERSION already exists"
-            exit 1
-          fi
-
-          current="$(grep -oE '\?ref=[^"]+' README.md | head -1 | cut -d= -f2)"
-          if [ -z "$current" ]; then
-            echo "::error::could not find a '?ref=' module version in README.md"
-            exit 1
-          fi
-          if [ "$current" = "$VERSION" ]; then
-            echo "::error::README.md already documents version $VERSION"
-            exit 1
-          fi
-
-          OLD="$current" NEW="$VERSION" perl -pi -e \
-            's/\?ref=\Q$ENV{OLD}\E\b/?ref=$ENV{NEW}/g' README.md
-
-          if [ -z "$(git diff --name-only)" ]; then
-            echo "::error::no README.md changes produced for $VERSION"
-            exit 1
-          fi
-
-          echo "previous=$current" >> "$GITHUB_OUTPUT"
-          echo "$current -> $VERSION" >> "$GITHUB_STEP_SUMMARY"
-
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-
-      # Pull requests opened with GITHUB_TOKEN do not trigger other workflows,
-      # so validate here instead of relying on ci.yml.
-      - name: Validate configuration
-        run: |
-          set -euo pipefail
-          terraform fmt -check -diff -recursive
-          for dir in . examples/quickstart examples/external-clickhouse; do
-            echo "::group::validate $dir"
-            terraform -chdir="$dir" init -backend=false -input=false
-            terraform -chdir="$dir" validate
-            echo "::endgroup::"
-          done
-
-      - name: Open release pull request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ inputs.version }}
-          PREVIOUS: ${{ steps.bump.outputs.previous }}
-        run: |
-          set -euo pipefail
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          branch="release/$VERSION"
-          git switch -C "$branch"
-          git commit -aqm "chore: bump version to $VERSION"
-          git push --force -q origin "$branch"
-
-          # Built line by line so no YAML indentation leaks into the body,
-          # where indented lines would render as code blocks.
-          body="$(printf '%s\n' \
-            "Releases \`$VERSION\` (previously \`$PREVIOUS\`)." \
-            "" \
-            "Merging this pull request creates and pushes the \`$VERSION\` tag and a GitHub release, via the \`tag\` job of [\`release.yml\`](.github/workflows/release.yml)." \
-            "" \
-            "\`terraform fmt -check\` and \`terraform validate\` (root module and both examples) ran in the job that opened this PR, because pull requests created by \`GITHUB_TOKEN\` do not trigger \`ci.yml\`.")"
-
-          # --base is omitted so gh targets the repository's default branch.
-          gh pr create --head "$branch" \
-            --title "chore: bump version to $VERSION" \
-            --body "$body"
-
-  tag:
-    name: Tag released version
+  release:
+    name: Tag and publish release
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
+    permissions:
+      contents: write # Create the tag and the GitHub release.
 
-      - name: Create tag and release if the documented version is new
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # A no-op unless the README names a version that has no tag yet, so
+      # ordinary README edits pass through untouched.
+      - name: Tag and release the documented version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
-
-          version="$(grep -oE '\?ref=[^"]+' README.md | head -1 | cut -d= -f2)"
-          if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'; then
-            echo "README.md documents '$version', which is not a release version - nothing to tag."
+          VERSION=$(grep -oE '\?ref=[^"]+' README.md | head -1 | cut -d= -f2)
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "README.md documents '$VERSION', which is not a release version."; exit 0; }
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists."
             exit 0
           fi
-
-          if git rev-parse -q --verify "refs/tags/$version" >/dev/null; then
-            echo "tag $version already exists - nothing to do."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git tag -a "$version" -m "Release $version"
-          git push -q origin "refs/tags/$version"
-
-          # Previous releases were tags only; the generated notes are additive.
-          prerelease=""
-          case "$version" in *-rc.*) prerelease="--prerelease" ;; esac
-          # shellcheck disable=SC2086
-          gh release create "$version" --title "$version" --generate-notes $prerelease
-
-          echo "released $version" >> "$GITHUB_STEP_SUMMARY"
+          # Creates the tag at this commit along with the release.
+          gh release create "$VERSION" --title "$VERSION" --generate-notes --target "$GITHUB_SHA"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,165 @@
+name: Release
+
+# Releasing is two steps, because `main` is protected and direct pushes are
+# rejected:
+#
+#   1. Run this workflow manually with the new version. It opens a pull request
+#      that bumps the module version documented in the README.
+#   2. Merge that pull request. The `tag` job then reconciles tags with the
+#      version declared in the README on `main`: it creates and pushes the
+#      matching tag and a GitHub release.
+#
+# The README `?ref=` value is therefore the single source of truth for the
+# module version, and step 2 is idempotent - a README change that does not
+# change the version is a no-op.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, e.g. 1.0.0"
+        required: true
+        type: string
+  push:
+    branches: [main]
+    paths: ["README.md"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release
+
+jobs:
+  prepare:
+    name: Prepare release
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Bump documented module version
+        id: bump
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'; then
+            echo "::error::'$VERSION' is not a valid version (expected X.Y.Z or X.Y.Z-rc.N)"
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "::error::tag $VERSION already exists"
+            exit 1
+          fi
+
+          current="$(grep -oE '\?ref=[^"]+' README.md | head -1 | cut -d= -f2)"
+          if [ -z "$current" ]; then
+            echo "::error::could not find a '?ref=' module version in README.md"
+            exit 1
+          fi
+          if [ "$current" = "$VERSION" ]; then
+            echo "::error::README.md already documents version $VERSION"
+            exit 1
+          fi
+
+          OLD="$current" NEW="$VERSION" perl -pi -e \
+            's/\?ref=\Q$ENV{OLD}\E\b/?ref=$ENV{NEW}/g' README.md
+
+          if [ -z "$(git diff --name-only)" ]; then
+            echo "::error::no README.md changes produced for $VERSION"
+            exit 1
+          fi
+
+          echo "previous=$current" >> "$GITHUB_OUTPUT"
+          echo "$current -> $VERSION" >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+
+      # Pull requests opened with GITHUB_TOKEN do not trigger other workflows,
+      # so validate here instead of relying on ci.yml.
+      - name: Validate configuration
+        run: |
+          set -euo pipefail
+          terraform fmt -check -diff -recursive
+          for dir in . examples/quickstart examples/external-clickhouse; do
+            echo "::group::validate $dir"
+            terraform -chdir="$dir" init -backend=false -input=false
+            terraform -chdir="$dir" validate
+            echo "::endgroup::"
+          done
+
+      - name: Open release pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          PREVIOUS: ${{ steps.bump.outputs.previous }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          branch="release/$VERSION"
+          git switch -C "$branch"
+          git commit -aqm "chore: bump version to $VERSION"
+          git push --force -q origin "$branch"
+
+          # Built line by line so no YAML indentation leaks into the body,
+          # where indented lines would render as code blocks.
+          body="$(printf '%s\n' \
+            "Releases \`$VERSION\` (previously \`$PREVIOUS\`)." \
+            "" \
+            "Merging this pull request creates and pushes the \`$VERSION\` tag and a GitHub release, via the \`tag\` job of [\`release.yml\`](.github/workflows/release.yml)." \
+            "" \
+            "\`terraform fmt -check\` and \`terraform validate\` (root module and both examples) ran in the job that opened this PR, because pull requests created by \`GITHUB_TOKEN\` do not trigger \`ci.yml\`.")"
+
+          # --base is omitted so gh targets the repository's default branch.
+          gh pr create --head "$branch" \
+            --title "chore: bump version to $VERSION" \
+            --body "$body"
+
+  tag:
+    name: Tag released version
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Create tag and release if the documented version is new
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          version="$(grep -oE '\?ref=[^"]+' README.md | head -1 | cut -d= -f2)"
+          if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'; then
+            echo "README.md documents '$version', which is not a release version - nothing to tag."
+            exit 0
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$version" >/dev/null; then
+            echo "tag $version already exists - nothing to do."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$version" -m "Release $version"
+          git push -q origin "refs/tags/$version"
+
+          # Previous releases were tags only; the generated notes are additive.
+          prerelease=""
+          case "$version" in *-rc.*) prerelease="--prerelease" ;; esac
+          # shellcheck disable=SC2086
+          gh release create "$version" --title "$version" --generate-notes $prerelease
+
+          echo "released $version" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/update-langfuse-versions.yml
+++ b/.github/workflows/update-langfuse-versions.yml
@@ -1,181 +1,81 @@
 name: Update Langfuse versions
 
-# Checks weekly whether a newer Langfuse Helm chart or Langfuse application
-# release exists and, if so, opens (or updates) a single pull request bumping
-# the module defaults. The PR is never merged automatically.
-
 on:
   schedule:
-    - cron: "0 9 * * 1" # Mondays, 09:00 UTC
-  workflow_dispatch:
+    - cron: "0 9 * * 1" # Run every Monday at 9 AM UTC
+  workflow_dispatch: # Allow manual triggering
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
-  group: update-langfuse-versions
-
-env:
-  UPDATE_BRANCH: chore/langfuse-version-updates
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   update:
-    name: Check for new versions
+    name: Check and update Langfuse versions
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Commit the version bumps.
+      pull-requests: write # Open the automated update pull request.
+
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - name: Resolve current and latest versions
-        id: versions
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Bump chart and application versions
         run: |
-          set -euo pipefail
-          semver='^[0-9]+\.[0-9]+\.[0-9]+$'
-
-          # Defaults declared by the module are the source of truth for "current".
-          read_default() {
+          # The variables.tf defaults are the source of truth for what we ship.
+          current() {
             sed -n "/^variable \"$1\"/,/^}/p" variables.tf \
               | sed -n 's/^  default *= *"\(.*\)"$/\1/p'
           }
-          chart_current="$(read_default langfuse_chart_version)"
-          app_current="$(read_default app_version)"
+          CHART=$(current langfuse_chart_version)
+          APP=$(current app_version)
 
-          # Helm chart releases live in langfuse/langfuse-k8s, tagged langfuse-X.Y.Z.
-          # That repo also tags other charts, so filter and pick the highest semver.
-          chart_latest="$(gh api 'repos/langfuse/langfuse-k8s/releases?per_page=100' \
-            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
-            | sed -n 's/^langfuse-//p' | grep -E "$semver" | sort -V | tail -1)"
+          # The chart is released from langfuse-k8s, which tags several charts,
+          # so keep only langfuse-X.Y.Z and take the highest.
+          CHART_LATEST=$(curl -sf "https://api.github.com/repos/langfuse/langfuse-k8s/releases?per_page=100" \
+            | jq -r '.[] | select(.draft or .prerelease | not) | .tag_name | select(startswith("langfuse-")) | ltrimstr("langfuse-")' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          APP_LATEST=$(curl -sf https://api.github.com/repos/langfuse/langfuse/releases/latest | jq -r '.tag_name | ltrimstr("v")')
 
-          # Langfuse application: newest stable release, tagged vX.Y.Z.
-          app_latest="$(gh api repos/langfuse/langfuse/releases/latest --jq '.tag_name' | sed 's/^v//')"
-
-          for pair in "chart_current:$chart_current" "app_current:$app_current" \
-                      "chart_latest:$chart_latest" "app_latest:$app_latest"; do
-            if ! printf '%s' "${pair#*:}" | grep -qE "$semver"; then
-              echo "::error::${pair%%:*} is not a valid semver value (got '${pair#*:}')"
-              exit 1
-            fi
+          for version in "$CHART" "$APP" "$CHART_LATEST" "$APP_LATEST"; do
+            [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Unsupported version format: '$version'" >&2; exit 1; }
           done
+          echo "Chart: $CHART -> $CHART_LATEST, application: $APP -> $APP_LATEST"
 
-          {
-            echo "chart_current=$chart_current"
-            echo "app_current=$app_current"
-            echo "chart_latest=$chart_latest"
-            echo "app_latest=$app_latest"
-          } >> "$GITHUB_OUTPUT"
-
-          if [ "$chart_current" = "$chart_latest" ] && [ "$app_current" = "$app_latest" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "chart: $chart_current -> $chart_latest" >> "$GITHUB_STEP_SUMMARY"
-          echo "app:   $app_current -> $app_latest" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Apply version bumps
-        if: steps.versions.outputs.changed == 'true'
-        env:
-          CHART_CURRENT: ${{ steps.versions.outputs.chart_current }}
-          CHART_LATEST: ${{ steps.versions.outputs.chart_latest }}
-          APP_CURRENT: ${{ steps.versions.outputs.app_current }}
-          APP_LATEST: ${{ steps.versions.outputs.app_latest }}
-        run: |
-          set -euo pipefail
-
-          # Each version is documented in several places (variables.tf defaults,
-          # README usage snippets and inputs table, examples). Replace the exact
-          # version string across tracked Terraform and Markdown files; the
-          # lookarounds keep it from matching inside a longer version number.
+          # Both versions are documented in variables.tf, the README and the
+          # examples. The lookarounds keep a version from matching inside a
+          # longer one.
           bump() {
             [ "$1" = "$2" ] && return 0
-            git ls-files -z '*.tf' '*.md' \
-              | OLD="$1" NEW="$2" xargs -0 perl -pi -e \
-                  's/(?<![0-9.])\Q$ENV{OLD}\E(?![0-9.])/$ENV{NEW}/g'
+            git ls-files -z '*.tf' '*.md' | OLD="$1" NEW="$2" xargs -0 perl -pi -e \
+              's/(?<![0-9.])\Q$ENV{OLD}\E(?![0-9.])/$ENV{NEW}/g'
           }
-          bump "$CHART_CURRENT" "$CHART_LATEST"
-          bump "$APP_CURRENT" "$APP_LATEST"
+          bump "$CHART" "$CHART_LATEST"
+          bump "$APP" "$APP_LATEST"
 
-          # Fail loudly if the authoritative defaults did not actually change,
-          # which would mean the file layout drifted from what bump() expects.
-          read_default() {
-            sed -n "/^variable \"$1\"/,/^}/p" variables.tf \
-              | sed -n 's/^  default *= *"\(.*\)"$/\1/p'
-          }
-          for pair in "langfuse_chart_version:$CHART_LATEST" "app_version:$APP_LATEST"; do
-            got="$(read_default "${pair%%:*}")"
-            if [ "$got" != "${pair#*:}" ]; then
-              echo "::error::${pair%%:*} default is '$got', expected '${pair#*:}'"
-              exit 1
-            fi
-          done
+          cat > "$RUNNER_TEMP/body.md" <<EOF
+          | Component | From | To |
+          | --- | --- | --- |
+          | Helm chart | \`$CHART\` | [\`$CHART_LATEST\`](https://github.com/langfuse/langfuse-k8s/releases/tag/langfuse-$CHART_LATEST) |
+          | Langfuse | \`$APP\` | [\`$APP_LATEST\`](https://github.com/langfuse/langfuse/releases/tag/v$APP_LATEST) |
 
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-        if: steps.versions.outputs.changed == 'true'
+          Rows where both versions match are unchanged. Read the linked release notes before merging: a major bump can need migration steps.
 
-      # Pull requests opened with GITHUB_TOKEN do not trigger other workflows,
-      # so validate the bumped tree here instead of relying on ci.yml.
-      - name: Validate bumped configuration
-        if: steps.versions.outputs.changed == 'true'
-        run: |
-          set -euo pipefail
-          terraform fmt -check -diff -recursive
-          for dir in . examples/quickstart examples/external-clickhouse; do
-            echo "::group::validate $dir"
-            terraform -chdir="$dir" init -backend=false -input=false
-            terraform -chdir="$dir" validate
-            echo "::endgroup::"
-          done
+          Opened by the weekly version check. Pull requests created with \`GITHUB_TOKEN\` do not trigger \`ci.yml\`, so close and reopen this one to run the checks.
+          EOF
 
-      - name: Open or update pull request
-        if: steps.versions.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CHART_CURRENT: ${{ steps.versions.outputs.chart_current }}
-          CHART_LATEST: ${{ steps.versions.outputs.chart_latest }}
-          APP_CURRENT: ${{ steps.versions.outputs.app_current }}
-          APP_LATEST: ${{ steps.versions.outputs.app_latest }}
-        run: |
-          set -euo pipefail
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          title="chore: update Langfuse versions"
-          body=""
-          summary=""
-
-          if [ "$CHART_CURRENT" != "$CHART_LATEST" ]; then
-            summary="chart $CHART_CURRENT -> $CHART_LATEST"
-            body="$body- Helm chart \`$CHART_CURRENT\` → [\`$CHART_LATEST\`](https://github.com/langfuse/langfuse-k8s/releases/tag/langfuse-$CHART_LATEST)"
-            if [ "${CHART_CURRENT%%.*}" != "${CHART_LATEST%%.*}" ]; then
-              body="$body — **major chart bump: review the chart release notes and migration guide before merging**"
-            fi
-            body="$body"$'\n'
-          fi
-
-          if [ "$APP_CURRENT" != "$APP_LATEST" ]; then
-            [ -n "$summary" ] && summary="$summary, "
-            summary="${summary}app $APP_CURRENT -> $APP_LATEST"
-            body="$body- Langfuse application \`$APP_CURRENT\` → [\`$APP_LATEST\`](https://github.com/langfuse/langfuse/releases/tag/v$APP_LATEST)"
-            if [ "${APP_CURRENT%%.*}" != "${APP_LATEST%%.*}" ]; then
-              body="$body — **major application bump: check the Langfuse upgrade guides before merging**"
-            fi
-            body="$body"$'\n'
-          fi
-
-          body="$body"$'\n''`terraform fmt -check` and `terraform validate` (root module and both examples) ran in the job that opened this PR, because pull requests created by `GITHUB_TOKEN` do not trigger `ci.yml`. Close and reopen this PR to run the full matrix.'
-          body="$body"$'\n\n''Opened automatically by [`update-langfuse-versions.yml`](.github/workflows/update-langfuse-versions.yml).'
-
-          git switch -C "$UPDATE_BRANCH"
-          git commit -aqm "$title" -m "$summary"
-          git push --force -q origin "$UPDATE_BRANCH"
-
-          if [ -n "$(gh pr list --head "$UPDATE_BRANCH" --state open --json number --jq '.[0].number // empty')" ]; then
-            echo "existing pull request updated with $summary"
-          else
-            # --base is omitted so gh targets the repository's default branch.
-            gh pr create --head "$UPDATE_BRANCH" --title "$title" --body "$body"
-          fi
+      # Creates nothing when both versions are already current, and updates the
+      # existing pull request when a newer version arrives before it is merged.
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update Langfuse versions"
+          title: "chore: update Langfuse versions"
+          body-path: ${{ runner.temp }}/body.md
+          branch: chore/langfuse-version-updates

--- a/.github/workflows/update-langfuse-versions.yml
+++ b/.github/workflows/update-langfuse-versions.yml
@@ -1,0 +1,181 @@
+name: Update Langfuse versions
+
+# Checks weekly whether a newer Langfuse Helm chart or Langfuse application
+# release exists and, if so, opens (or updates) a single pull request bumping
+# the module defaults. The PR is never merged automatically.
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Mondays, 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-langfuse-versions
+
+env:
+  UPDATE_BRANCH: chore/langfuse-version-updates
+
+jobs:
+  update:
+    name: Check for new versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Resolve current and latest versions
+        id: versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          semver='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+          # Defaults declared by the module are the source of truth for "current".
+          read_default() {
+            sed -n "/^variable \"$1\"/,/^}/p" variables.tf \
+              | sed -n 's/^  default *= *"\(.*\)"$/\1/p'
+          }
+          chart_current="$(read_default langfuse_chart_version)"
+          app_current="$(read_default app_version)"
+
+          # Helm chart releases live in langfuse/langfuse-k8s, tagged langfuse-X.Y.Z.
+          # That repo also tags other charts, so filter and pick the highest semver.
+          chart_latest="$(gh api 'repos/langfuse/langfuse-k8s/releases?per_page=100' \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+            | sed -n 's/^langfuse-//p' | grep -E "$semver" | sort -V | tail -1)"
+
+          # Langfuse application: newest stable release, tagged vX.Y.Z.
+          app_latest="$(gh api repos/langfuse/langfuse/releases/latest --jq '.tag_name' | sed 's/^v//')"
+
+          for pair in "chart_current:$chart_current" "app_current:$app_current" \
+                      "chart_latest:$chart_latest" "app_latest:$app_latest"; do
+            if ! printf '%s' "${pair#*:}" | grep -qE "$semver"; then
+              echo "::error::${pair%%:*} is not a valid semver value (got '${pair#*:}')"
+              exit 1
+            fi
+          done
+
+          {
+            echo "chart_current=$chart_current"
+            echo "app_current=$app_current"
+            echo "chart_latest=$chart_latest"
+            echo "app_latest=$app_latest"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$chart_current" = "$chart_latest" ] && [ "$app_current" = "$app_latest" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "chart: $chart_current -> $chart_latest" >> "$GITHUB_STEP_SUMMARY"
+          echo "app:   $app_current -> $app_latest" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Apply version bumps
+        if: steps.versions.outputs.changed == 'true'
+        env:
+          CHART_CURRENT: ${{ steps.versions.outputs.chart_current }}
+          CHART_LATEST: ${{ steps.versions.outputs.chart_latest }}
+          APP_CURRENT: ${{ steps.versions.outputs.app_current }}
+          APP_LATEST: ${{ steps.versions.outputs.app_latest }}
+        run: |
+          set -euo pipefail
+
+          # Each version is documented in several places (variables.tf defaults,
+          # README usage snippets and inputs table, examples). Replace the exact
+          # version string across tracked Terraform and Markdown files; the
+          # lookarounds keep it from matching inside a longer version number.
+          bump() {
+            [ "$1" = "$2" ] && return 0
+            git ls-files -z '*.tf' '*.md' \
+              | OLD="$1" NEW="$2" xargs -0 perl -pi -e \
+                  's/(?<![0-9.])\Q$ENV{OLD}\E(?![0-9.])/$ENV{NEW}/g'
+          }
+          bump "$CHART_CURRENT" "$CHART_LATEST"
+          bump "$APP_CURRENT" "$APP_LATEST"
+
+          # Fail loudly if the authoritative defaults did not actually change,
+          # which would mean the file layout drifted from what bump() expects.
+          read_default() {
+            sed -n "/^variable \"$1\"/,/^}/p" variables.tf \
+              | sed -n 's/^  default *= *"\(.*\)"$/\1/p'
+          }
+          for pair in "langfuse_chart_version:$CHART_LATEST" "app_version:$APP_LATEST"; do
+            got="$(read_default "${pair%%:*}")"
+            if [ "$got" != "${pair#*:}" ]; then
+              echo "::error::${pair%%:*} default is '$got', expected '${pair#*:}'"
+              exit 1
+            fi
+          done
+
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        if: steps.versions.outputs.changed == 'true'
+
+      # Pull requests opened with GITHUB_TOKEN do not trigger other workflows,
+      # so validate the bumped tree here instead of relying on ci.yml.
+      - name: Validate bumped configuration
+        if: steps.versions.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          terraform fmt -check -diff -recursive
+          for dir in . examples/quickstart examples/external-clickhouse; do
+            echo "::group::validate $dir"
+            terraform -chdir="$dir" init -backend=false -input=false
+            terraform -chdir="$dir" validate
+            echo "::endgroup::"
+          done
+
+      - name: Open or update pull request
+        if: steps.versions.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHART_CURRENT: ${{ steps.versions.outputs.chart_current }}
+          CHART_LATEST: ${{ steps.versions.outputs.chart_latest }}
+          APP_CURRENT: ${{ steps.versions.outputs.app_current }}
+          APP_LATEST: ${{ steps.versions.outputs.app_latest }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          title="chore: update Langfuse versions"
+          body=""
+          summary=""
+
+          if [ "$CHART_CURRENT" != "$CHART_LATEST" ]; then
+            summary="chart $CHART_CURRENT -> $CHART_LATEST"
+            body="$body- Helm chart \`$CHART_CURRENT\` → [\`$CHART_LATEST\`](https://github.com/langfuse/langfuse-k8s/releases/tag/langfuse-$CHART_LATEST)"
+            if [ "${CHART_CURRENT%%.*}" != "${CHART_LATEST%%.*}" ]; then
+              body="$body — **major chart bump: review the chart release notes and migration guide before merging**"
+            fi
+            body="$body"$'\n'
+          fi
+
+          if [ "$APP_CURRENT" != "$APP_LATEST" ]; then
+            [ -n "$summary" ] && summary="$summary, "
+            summary="${summary}app $APP_CURRENT -> $APP_LATEST"
+            body="$body- Langfuse application \`$APP_CURRENT\` → [\`$APP_LATEST\`](https://github.com/langfuse/langfuse/releases/tag/v$APP_LATEST)"
+            if [ "${APP_CURRENT%%.*}" != "${APP_LATEST%%.*}" ]; then
+              body="$body — **major application bump: check the Langfuse upgrade guides before merging**"
+            fi
+            body="$body"$'\n'
+          fi
+
+          body="$body"$'\n''`terraform fmt -check` and `terraform validate` (root module and both examples) ran in the job that opened this PR, because pull requests created by `GITHUB_TOKEN` do not trigger `ci.yml`. Close and reopen this PR to run the full matrix.'
+          body="$body"$'\n\n''Opened automatically by [`update-langfuse-versions.yml`](.github/workflows/update-langfuse-versions.yml).'
+
+          git switch -C "$UPDATE_BRANCH"
+          git commit -aqm "$title" -m "$summary"
+          git push --force -q origin "$UPDATE_BRANCH"
+
+          if [ -n "$(gh pr list --head "$UPDATE_BRANCH" --state open --json number --jq '.[0].number // empty')" ]; then
+            echo "existing pull request updated with $summary"
+          else
+            # --base is omitted so gh targets the repository's default branch.
+            gh pr create --head "$UPDATE_BRANCH" --title "$title" --body "$body"
+          fi


### PR DESCRIPTION
Two workflows: a weekly upstream-version check, and release tagging from a version input.

## `update-langfuse-versions.yml` — weekly version check

Runs **Mondays 09:00 UTC** (plus `workflow_dispatch`). It:

1. reads the current `langfuse_chart_version` / `app_version` defaults out of `variables.tf` (the module's source of truth),
2. resolves the newest **stable** Helm chart from `langfuse-k8s` releases (tags `langfuse-X.Y.Z`, filtered because that repo tags other charts too, highest semver wins) and the newest **stable** Langfuse application release (`releases/latest`, which excludes prereleases),
3. exits quietly when both match, otherwise rewrites every documented occurrence of the old version — `variables.tf` defaults, both README usage snippets, the README inputs table, `examples/quickstart` — and asserts afterwards that the `variables.tf` defaults really changed (so the job fails loudly instead of opening a half-bumped PR if the file layout ever drifts),
4. runs `fmt -check` + `validate` on root and both examples,
5. force-pushes a fixed branch (`chore/langfuse-version-updates`) and opens **or updates** one PR — so a stale bump gets refreshed each Monday instead of piling up new PRs.

A chart or application **major** bump is called out in bold in the PR body with a link to the release notes, since those need a human read before merging.

## `release.yml` — version in, tag out

`main` is protected (PR required), so a workflow cannot push a release commit straight to it. This is therefore two steps, and the second is automatic:

1. **Run the workflow** with `version` (e.g. `1.0.0`). It validates the format, refuses a version whose tag already exists, rewrites the README `?ref=`, validates, and opens a `chore: bump version to X` PR — matching the existing release-commit convention.
2. **Merge that PR.** The `tag` job then reconciles tags against the version the README declares on `main`: it creates the annotated tag, pushes it, and cuts a GitHub release with generated notes.

Making the README `?ref=` the source of truth (rather than parsing the commit message) keeps the tag job **idempotent** — an unrelated README edit reads the current version, sees the tag already exists, and no-ops.

Two things worth your call:

- **GitHub releases are new here** — the repo has only ever had tags. The generated notes are additive; drop the `gh release create` line if you'd rather keep tags only.
- **If you'd prefer one-step releases** (workflow pushes commit + tag directly, no PR), that needs a bypass for `github-actions[bot]` on the `main` protection rule. Say the word and I'll collapse the two jobs into one.

## Test plan

Everything below was run locally against this branch; I could not dispatch the workflows themselves, since both `schedule` and `workflow_dispatch` only become available once the file is on the default branch.

- [x] Both files parse as YAML; every `run:` block passes `bash -n` (expressions stubbed out).
- [x] **Version discovery executed for real**: chart → `2.0.0`, app → `4.16.0`; current defaults read as `2.0.0` / `4.14.0`. So the first run will open a real PR bumping the app to 4.16.0, chart untouched.
- [x] **Bump executed**: rewrote exactly the 6 intended occurrences across `README.md`, `variables.tf`, `examples/quickstart/quickstart.tf` and nothing else; post-conditions passed; `fmt -check` clean and `validate` green on root + both examples afterwards; then reverted.
- [x] **PR/commit text checked** at column 0 — no YAML indentation leaking into the body (indented lines would render as code blocks).
- [x] **Release input validation exercised**: `1.0.0` and `1.0.0-rc.1` accepted with the correct README rewrite; `0.3.4` rejected (tag exists), `1.0` and `v1.0.0` rejected (format).
- [x] **Tag-job idempotency confirmed**: on current `main` it reads `0.3.4`, sees the tag, and no-ops.
- [ ] First real scheduled/dispatched run happens after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
