### PR TITLE
ci: release the versions the weekly check bumps

### DIFF
--- a/.github/workflows/update-langfuse-versions.yml
+++ b/.github/workflows/update-langfuse-versions.yml
@@ -58,6 +58,17 @@ jobs:
           bump "$CHART" "$CHART_LATEST"
           bump "$APP" "$APP_LATEST"
 
+          # A bump that is never released does not reach anyone pinning a tag, so
+          # release it too. Only minor and patch updates: a major upstream bump
+          # needs a deliberately chosen module version.
+          REF=$(grep -oE '\?ref=[^"]+' README.md | head -1 | cut -d= -f2)
+          RELEASE="Leaving the module version alone, because a major upstream bump needs a deliberate one. Run the release workflow after merging."
+          if [ "${CHART%%.*}" = "${CHART_LATEST%%.*}" ] && [ "${APP%%.*}" = "${APP_LATEST%%.*}" ]; then
+            NEXT="${REF%.*}.$(( ${REF##*.} + 1 ))"
+            OLD="$REF" NEW="$NEXT" perl -pi -e 's{\?ref=\Q$ENV{OLD}\E\b}{?ref=$ENV{NEW}}g' README.md
+            RELEASE="Merging this releases \`$NEXT\`."
+          fi
+
           cat > "$RUNNER_TEMP/body.md" <<EOF
           | Component | From | To |
           | --- | --- | --- |
@@ -65,6 +76,8 @@ jobs:
           | Langfuse | \`$APP\` | [\`$APP_LATEST\`](https://github.com/langfuse/langfuse/releases/tag/v$APP_LATEST) |
 
           Rows where both versions match are unchanged. Read the linked release notes before merging: a major bump can need migration steps.
+
+          $RELEASE
 
           Opened by the weekly version check. Pull requests created with \`GITHUB_TOKEN\` do not trigger \`ci.yml\`, so close and reopen this one to run the checks.
           EOF


### PR DESCRIPTION
Closes the loop you spotted: [this Release run](https://github.com/langfuse/langfuse-terraform-gcp/actions/runs/32749127556) fired on #38 and no-opped, because the weekly updater edits the README inputs table but leaves `?ref=` alone. So `main` ships Langfuse 4.16.0 while tag `1.0.1` still ships 4.14.0.

The updater now bumps the module's patch version in the same pull request, so merging it tags and publishes the release. Patch is the right level — the module's inputs and outputs do not change when a default version moves.

**Nine lines, one conditional:** minor and patch updates release themselves; a major upstream bump leaves the version alone and says so in the PR body, since that needs a deliberately chosen module version. Drop that `if` if you would rather have no conditional at all — the cost is that a chart or Langfuse major would go out as a module patch.

## Test plan

- [x] YAML parses; the `run` block passes `bash -n`; `fmt -check` clean.
- [x] Both paths exercised locally against this repo: the real pending update (app `4.14.0 → 4.16.0`) bumps `?ref=` to `1.0.2` and the body reads "Merging this releases \`1.0.2\`"; a faked chart major (`1.5.41 → 2.0.0`) leaves `?ref=` at `1.0.1` with the explanation.
- [x] No manual release needed to get going: the next weekly pull request carries the pending 4.16.0 change into `1.0.2` by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)